### PR TITLE
Remove unused variable from DiskView

### DIFF
--- a/Smith/Views/DiskView.swift
+++ b/Smith/Views/DiskView.swift
@@ -11,7 +11,6 @@ import UniformTypeIdentifiers
 struct DiskView: View {
     @StateObject private var fileManager = FileSystemManager()
     @EnvironmentObject private var smithAgent: SmithAgent
-    @State private var selectedFiltryeURL: URL?
     @State private var expandedFolders: Set<URL> = []
     
     var body: some View {


### PR DESCRIPTION
## Summary
- clean up unused state property in `DiskView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc Smith/SmithApp.swift -o smith` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6851970eba6883218da42772d32cc52f