### PR TITLE
Fix CPU temperature estimate scaling

### DIFF
--- a/Smith/Core/CPUMonitor.swift
+++ b/Smith/Core/CPUMonitor.swift
@@ -277,68 +277,93 @@ class CPUMonitor: ObservableObject {
     }
     
     nonisolated private func getOSXCPUTempTemperature() -> Double {
-        // Try to use osx-cpu-temp if installed
-        let task = Process()
-        task.launchPath = "/opt/homebrew/bin/osx-cpu-temp"
-        task.arguments = []
-        
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-        
-        do {
-            try task.run()
-            task.waitUntilExit()
-            
-            if task.terminationStatus == 0 {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                
-                // Parse output like "61.2°C"
-                let cleanOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let tempValue = Double(cleanOutput.replacingOccurrences(of: "°C", with: "")) {
-                    return tempValue
+        // Try to use osx-cpu-temp if installed in common Homebrew locations
+        let possiblePaths = [
+            "/opt/homebrew/bin/osx-cpu-temp",
+            "/usr/local/bin/osx-cpu-temp",
+            "/usr/bin/osx-cpu-temp"
+        ]
+
+        for path in possiblePaths {
+            guard FileManager.default.isExecutableFile(atPath: path) else { continue }
+
+            let task = Process()
+            task.launchPath = path
+            task.arguments = []
+
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = Pipe()
+
+            do {
+                try task.run()
+                task.waitUntilExit()
+
+                if task.terminationStatus == 0 {
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+
+                    // Parse output like "61.2°C"
+                    let cleanOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let tempValue = Double(cleanOutput.replacingOccurrences(of: "°C", with: "")) {
+                        return tempValue
+                    }
                 }
+            } catch {
+                // Try next path
+                continue
             }
-        } catch {
-            // Tool not available, continue to next method
         }
-        
+
         return 0.0
     }
     
     nonisolated private func getIStatsTemperature() -> Double {
-        // Try istats command line tool
-        let task = Process()
-        task.launchPath = "/usr/local/bin/istats"
-        task.arguments = ["cpu", "temp", "--value-only"]
-        
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = Pipe()
-        
-        do {
-            try task.run()
-            task.waitUntilExit()
-            
-            if task.terminationStatus == 0 {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8) ?? ""
-                
-                if let tempValue = Double(output.trimmingCharacters(in: .whitespacesAndNewlines)) {
-                    return tempValue
+        // Try istats command line tool from common Homebrew locations
+        let possiblePaths = [
+            "/opt/homebrew/bin/istats",
+            "/usr/local/bin/istats"
+        ]
+
+        for path in possiblePaths {
+            guard FileManager.default.isExecutableFile(atPath: path) else { continue }
+
+            let task = Process()
+            task.launchPath = path
+            task.arguments = ["cpu", "temp", "--value-only"]
+
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.standardError = Pipe()
+
+            do {
+                try task.run()
+                task.waitUntilExit()
+
+                if task.terminationStatus == 0 {
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+
+                    if let tempValue = Double(output.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                        return tempValue
+                    }
                 }
+            } catch {
+                // Try next path
+                continue
             }
-        } catch {
-            // Tool not available, continue to next method
         }
-        
+
         return 0.0
     }
     
     nonisolated private func getRealisticTemperatureEstimate() -> Double {
         // Get actual CPU usage for better estimation
-        let currentUsage = getAccurateCPUUsage()
+        // Normalize overall usage to a 0-100% range since
+        // `getAccurateCPUUsage()` scales usage by the number of cores.
+        let rawUsage = getAccurateCPUUsage()
+        let normalizedUsage = rawUsage / Double(max(internalCoreCount, 1))
+        let currentUsage = max(0, min(100, normalizedUsage))
         
         // Base temperature ranges for different Mac models
         let baseIdleTemp: Double = 40.0  // More realistic idle temp
@@ -371,7 +396,7 @@ class CPUMonitor: ObservableObject {
             // Add thermal cycle and some randomness
             estimatedTemp += thermalCycle + Double.random(in: -2.0...2.0)
             
-            return max(35.0, min(105.0, estimatedTemp))
+            return max(35.0, min(100.0, estimatedTemp))
         }
         
         // Simple fallback without uptime variation
@@ -386,7 +411,7 @@ class CPUMonitor: ObservableObject {
         // Add some randomness for realism
         estimatedTemp += Double.random(in: -2.0...2.0)
         
-        return max(35.0, min(105.0, estimatedTemp))
+        return max(35.0, min(100.0, estimatedTemp))
     }
     
     nonisolated private func detectThermalThrottling() -> Bool {


### PR DESCRIPTION
## Summary
- normalize CPU usage by core count in `getRealisticTemperatureEstimate`
- clamp fallback temps to 100°C

## Testing
- `swift test -c release` *(fails: no Package.swift)*
- `make test` *(fails: no target)*

------
https://chatgpt.com/codex/tasks/task_e_6851960659508321805579e6635187fd