### PR TITLE
Refactor view padding to use constants

### DIFF
--- a/Smith/Views/AdvancedSettingsView.swift
+++ b/Smith/Views/AdvancedSettingsView.swift
@@ -86,7 +86,7 @@ struct AdvancedSettingsView: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
-                    .padding(8)
+                    .padding(Spacing.small)
                     .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 6))
                 }
             }

--- a/Smith/Views/BackgroundSettingsView.swift
+++ b/Smith/Views/BackgroundSettingsView.swift
@@ -46,7 +46,7 @@ struct BackgroundSettingsView: View {
                                                    showingUninstallConfirmation: $showingUninstallConfirmation)
                     }
                 }
-                .padding(.vertical, 8)
+                .padding(.vertical, Spacing.small)
             }
             
             if launchAgent.isLaunchAgentInstalled {
@@ -302,7 +302,7 @@ struct IntensitySelector: View {
                             .scaleEffect(0.8)
                     }
                 }
-                .padding(.vertical, 4)
+                .padding(.vertical, Spacing.xsmall)
             }
         }
     }
@@ -406,7 +406,7 @@ struct StatCard: View {
                 Spacer()
             }
         }
-        .padding(8)
+        .padding(Spacing.small)
         .background(color.opacity(0.1))
         .cornerRadius(6)
     }

--- a/Smith/Views/BatteryView.swift
+++ b/Smith/Views/BatteryView.swift
@@ -96,7 +96,7 @@ struct BatteryView: View {
                     Spacer()
                 }
             }
-            .padding(8)
+            .padding(Spacing.small)
             .background(.gray.opacity(0.1))
             
             // Ultra-Compact Power Sources and Tips
@@ -114,7 +114,7 @@ struct BatteryView: View {
                                 UltraCompactPowerSourceView(source: source)
                             }
                         }
-                        .padding(.horizontal, 8)
+                        .padding(.horizontal, Spacing.small)
                     }
                     
                     // Ultra-Compact Battery Tips
@@ -130,7 +130,7 @@ struct BatteryView: View {
                             UltraCompactTipView(icon: "app.badge.minus", title: "Close Background Apps")
                         }
                     }
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, Spacing.small)
                 }
             }
             .frame(maxHeight: 80)
@@ -198,8 +198,8 @@ struct PowerSourceRowView: View {
                     .foregroundColor(source.isCharging ? .green : .gray)
             }
         }
-        .padding(.vertical, 4)
-        .padding(.horizontal, 8)
+        .padding(.vertical, Spacing.xsmall)
+        .padding(.horizontal, Spacing.small)
         .background(.gray.opacity(0.1))
         .cornerRadius(8)
     }
@@ -228,7 +228,7 @@ struct TipRowView: View {
             
             Spacer()
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Spacing.xsmall)
     }
 }
 
@@ -262,8 +262,8 @@ struct CompactPowerSourceView: View {
                     .foregroundColor(source.isCharging ? .green : .gray)
             }
         }
-        .padding(.vertical, 2)
-        .padding(.horizontal, 6)
+        .padding(.vertical, Spacing.xsmall)
+        .padding(.horizontal, Spacing.small)
         .background(.gray.opacity(0.1))
         .cornerRadius(4)
     }
@@ -287,7 +287,7 @@ struct CompactTipView: View {
             
             Spacer()
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, Spacing.xsmall)
     }
 }
 
@@ -313,8 +313,8 @@ struct UltraCompactPowerSourceView: View {
                 .font(.caption2)
                 .foregroundColor(source.isCharging ? .green : .gray)
         }
-        .padding(.vertical, 1)
-        .padding(.horizontal, 4)
+        .padding(.vertical, Spacing.xsmall)
+        .padding(.horizontal, Spacing.xsmall)
         .background(.gray.opacity(0.1))
         .cornerRadius(3)
     }
@@ -338,7 +338,7 @@ struct UltraCompactTipView: View {
             
             Spacer()
         }
-        .padding(.vertical, 1)
+        .padding(.vertical, Spacing.xsmall)
     }
 }
 

--- a/Smith/Views/CPUView.swift
+++ b/Smith/Views/CPUView.swift
@@ -86,7 +86,7 @@ struct CPUView: View {
                     Spacer()
                 }
             }
-            .padding(8)
+            .padding(Spacing.small)
             .background(.gray.opacity(0.1))
             
             // Ultra-Compact Process List
@@ -105,8 +105,8 @@ struct CPUView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.mini)
                 }
-                .padding(.horizontal, 8)
-                .padding(.top, 4)
+                .padding(.horizontal, Spacing.small)
+                .padding(.top, Spacing.xsmall)
                 
                 ScrollView {
                     LazyVStack(spacing: 1) {
@@ -116,7 +116,7 @@ struct CPUView: View {
                             }
                         }
                     }
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, Spacing.small)
                 }
                 .frame(maxHeight: 100)
             }
@@ -216,7 +216,7 @@ struct ProcessRowView: View {
             }
             .frame(width: 80)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Spacing.xsmall)
         .contentShape(Rectangle())
         .onTapGesture {
             onTap()
@@ -265,8 +265,8 @@ struct CompactProcessRowView: View {
             }
             .frame(width: 60)
         }
-        .padding(.vertical, 2)
-        .padding(.horizontal, 4)
+        .padding(.vertical, Spacing.xsmall)
+        .padding(.horizontal, Spacing.xsmall)
         .background(.gray.opacity(0.05), in: RoundedRectangle(cornerRadius: 4))
         .contentShape(Rectangle())
         .onTapGesture {

--- a/Smith/Views/ChatView.swift
+++ b/Smith/Views/ChatView.swift
@@ -47,8 +47,8 @@ struct ChatView: View {
                         .font(.caption)
                         .foregroundColor(.green)
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
+                .padding(.horizontal, Spacing.medium)
+                .padding(.vertical, Spacing.small)
                 .background(.green.opacity(0.1), in: Capsule())
                 .overlay(Capsule().stroke(.green.opacity(0.3), lineWidth: 1))
             }
@@ -289,7 +289,7 @@ struct FocusedFileCard: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(8)
+        .padding(Spacing.small)
         .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)
@@ -333,8 +333,8 @@ struct OptimizedMessageBubble: View {
                 Text(message.content)
                     .font(.subheadline)
                     .foregroundColor(.white)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
+                    .padding(.horizontal, Spacing.medium)
+                    .padding(.vertical, Spacing.small)
                     .background(
                         message.isUser ? .blue.opacity(0.2) : .cyan.opacity(0.1),
                         in: RoundedRectangle(cornerRadius: 14)
@@ -380,8 +380,8 @@ struct CompactTypingIndicator: View {
                             .animation(.easeInOut(duration: 0.4).repeatForever(), value: animationPhase)
                     }
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+                .padding(.horizontal, Spacing.medium)
+                .padding(.vertical, Spacing.small)
                 .background(.cyan.opacity(0.1), in: RoundedRectangle(cornerRadius: 14))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14)
@@ -440,8 +440,8 @@ struct CompactFocusedFileCard: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.horizontal, Spacing.small)
+        .padding(.vertical, Spacing.small)
         .background(.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)

--- a/Smith/Views/DiskView.swift
+++ b/Smith/Views/DiskView.swift
@@ -55,7 +55,7 @@ struct DiskView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            .padding(6)
+            .padding(Spacing.small)
             .background(.gray.opacity(0.1))
             
             // Ultra-Compact File browser with info panel
@@ -95,7 +95,7 @@ struct DiskView: View {
                                         }
                                 }
                             }
-                            .padding(.horizontal, 4)
+                            .padding(.horizontal, Spacing.xsmall)
                         }
                     }
                 }
@@ -138,7 +138,7 @@ struct DiskView: View {
                                 .controlSize(.mini)
                             }
                         }
-                        .padding(6)
+                        .padding(Spacing.small)
                     } else {
                         VStack {
                             Image(systemName: "doc.questionmark")
@@ -150,7 +150,7 @@ struct DiskView: View {
                                 .foregroundColor(.gray)
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .padding(6)
+                        .padding(Spacing.small)
                     }
                 }
                 .frame(width: 100)
@@ -210,7 +210,7 @@ struct FileRowView: View {
             
             Spacer()
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, Spacing.xsmall)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(isSelected ? .cyan.opacity(0.2) : .clear)
@@ -251,7 +251,7 @@ struct CompactFileRowView: View {
             
             Spacer()
         }
-        .padding(.vertical, 1)
+        .padding(.vertical, Spacing.xsmall)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(isSelected ? .cyan.opacity(0.2) : .clear)
@@ -292,8 +292,8 @@ struct UltraCompactFileRowView: View {
             
             Spacer()
         }
-        .padding(.vertical, 1)
-        .padding(.horizontal, 3)
+        .padding(.vertical, Spacing.xsmall)
+        .padding(.horizontal, Spacing.xsmall)
         .background(
             RoundedRectangle(cornerRadius: 3)
                 .fill(isSelected ? .cyan.opacity(0.2) : .clear)

--- a/Smith/Views/FloatingPanelSettingsView.swift
+++ b/Smith/Views/FloatingPanelSettingsView.swift
@@ -37,7 +37,7 @@ struct FloatingPanelSettingsView: View {
                                 .buttonStyle(.bordered)
                                 .controlSize(.small)
                             }
-                            .padding(.vertical, 4)
+                            .padding(.vertical, Spacing.xsmall)
                         }
                     }
                     .padding()

--- a/Smith/Views/IntegrationSettingsView.swift
+++ b/Smith/Views/IntegrationSettingsView.swift
@@ -80,8 +80,8 @@ struct IntegrationStatusRow: View {
                 .foregroundColor(status ? .green : .red)
                 .font(.caption)
                 .fontWeight(.medium)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
+                .padding(.horizontal, Spacing.small)
+                .padding(.vertical, Spacing.xsmall)
                 .background((status ? Color.green : Color.red).opacity(0.15), in: Capsule())
         }
     }

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -107,8 +107,8 @@ struct MainView: View {
                         .buttonStyle(.plain)
                         .help("Settings")
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.top, 6)
+                    .padding(.horizontal, Spacing.large)
+                    .padding(.top, Spacing.small)
                     
                     // Enhanced System Overview Cards with Floating Panel Integration
                     HStack(spacing: 3) {
@@ -154,8 +154,8 @@ struct MainView: View {
                             selectedSystemView = .automation
                         }
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 6)
+                    .padding(.horizontal, Spacing.large)
+                    .padding(.bottom, Spacing.small)
                 }
                 .background(.ultraThinMaterial)
                 .overlay(
@@ -209,8 +209,8 @@ struct MainView: View {
                                 }
                             }
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.top, 12)
+                        .padding(.horizontal, Spacing.large)
+                        .padding(.top, Spacing.medium)
                         
                         // Enhanced Dynamic Content Area with Automation
                         VStack(spacing: 12) {
@@ -230,7 +230,7 @@ struct MainView: View {
                                 EnhancedIntegrationSection()
                             }
                         }
-                        .padding(.horizontal, 16)
+                        .padding(.horizontal, Spacing.large)
                         
                         // Bottom padding
                         Rectangle()
@@ -278,8 +278,8 @@ struct MainView: View {
                                 .foregroundColor(automationStatusColor)
                                 .fontWeight(.medium)
                         }
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
+                        .padding(.horizontal, Spacing.xsmall)
+                        .padding(.vertical, Spacing.xsmall)
                         .background(automationStatusColor.opacity(0.1), in: Capsule())
                         
                         // AI Connection Status
@@ -300,14 +300,14 @@ struct MainView: View {
                                 .foregroundColor(aiStatusColor)
                                 .fontWeight(.medium)
                         }
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .padding(.horizontal, Spacing.small)
+                        .padding(.vertical, Spacing.xsmall)
                         .background(aiStatusColor.opacity(0.08), in: Capsule())
                         .overlay(Capsule().stroke(aiStatusColor.opacity(0.2), lineWidth: 0.3))
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
+                .padding(.horizontal, Spacing.large)
+                .padding(.vertical, Spacing.small)
                 .background(.ultraThinMaterial)
                 .overlay(
                     Rectangle()
@@ -477,7 +477,7 @@ struct CompactAutomationSection: View {
                                     .fill(task.priority.color)
                                     .frame(width: 6, height: 6)
                             }
-                            .padding(.vertical, 2)
+                            .padding(.vertical, Spacing.xsmall)
                         }
                     }
                     
@@ -508,17 +508,17 @@ struct CompactAutomationSection: View {
                             .buttonStyle(.bordered)
                             .controlSize(.mini)
                         }
-                        .padding(.top, 4)
+                        .padding(.top, Spacing.xsmall)
                     }
                 } else {
                     Text("Enable automation for smart system maintenance")
                         .font(.caption)
                         .foregroundColor(.gray)
                         .multilineTextAlignment(.center)
-                        .padding(.vertical, 8)
+                        .padding(.vertical, Spacing.small)
                 }
             }
-            .padding(12)
+            .padding(Spacing.medium)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
@@ -609,7 +609,7 @@ struct AutomationSettingsView: View {
                         ))
                         .toggleStyle(.switch)
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, Spacing.xsmall)
                 }
             }
             
@@ -709,8 +709,8 @@ struct CompactSystemCard: View {
                     .minimumScaleFactor(0.8)
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 6)
-            .padding(.horizontal, 4)
+            .padding(.vertical, Spacing.small)
+            .padding(.horizontal, Spacing.xsmall)
             .background(
                 isActive ? color.opacity(0.15) : .clear,
                 in: RoundedRectangle(cornerRadius: 6)
@@ -778,7 +778,7 @@ struct CompactCPUSection: View {
                     CompactStatItem(title: "Freq", value: "3.2GHz", color: .blue)
                 }
             }
-            .padding(12)
+            .padding(Spacing.medium)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
@@ -821,8 +821,8 @@ struct CompactBatterySection: View {
                         .font(.caption)
                         .fontWeight(.medium)
                         .foregroundColor(.green)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .padding(.horizontal, Spacing.small)
+                        .padding(.vertical, Spacing.xsmall)
                         .background(.green.opacity(0.15), in: Capsule())
                 }
                 
@@ -858,7 +858,7 @@ struct CompactBatterySection: View {
                     Spacer()
                 }
             }
-            .padding(12)
+            .padding(Spacing.medium)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
@@ -928,7 +928,7 @@ struct CompactDiskSection: View {
                     Spacer()
                 }
             }
-            .padding(12)
+            .padding(Spacing.medium)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
@@ -962,7 +962,7 @@ struct CompactStatItem: View {
                 .foregroundColor(.gray)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 3)
+        .padding(.vertical, Spacing.xsmall)
         .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 3))
     }
 }
@@ -984,8 +984,8 @@ struct EnhancedIntegrationSection: View {
                         .font(.caption)
                         .fontWeight(.medium)
                         .foregroundColor(.green)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .padding(.horizontal, Spacing.small)
+                        .padding(.vertical, Spacing.xsmall)
                         .background(.green.opacity(0.15), in: Capsule())
                 }
                 
@@ -1031,7 +1031,7 @@ struct ModernIntegrationCard: View {
                 .frame(width: 4, height: 4)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 6)
+        .padding(.vertical, Spacing.small)
         .background((status ? Color.green : Color.red).opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
     }
 }

--- a/Smith/Views/SystemIntegrationView.swift
+++ b/Smith/Views/SystemIntegrationView.swift
@@ -85,8 +85,8 @@ struct SystemIntegrationView: View {
                         
                         Text(systemIntegration.isURLSchemeEnabled ? "Active" : "Inactive")
                             .font(.caption)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.horizontal, Spacing.small)
+                            .padding(.vertical, Spacing.xsmall)
                             .background(systemIntegration.isURLSchemeEnabled ? Color.green.opacity(0.2) : Color.red.opacity(0.2))
                             .cornerRadius(4)
                     }
@@ -142,8 +142,8 @@ struct SystemIntegrationView: View {
                         
                         Text(systemIntegration.isAppleScriptEnabled ? "Active" : "Inactive")
                             .font(.caption)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.horizontal, Spacing.small)
+                            .padding(.vertical, Spacing.xsmall)
                             .background(systemIntegration.isAppleScriptEnabled ? Color.green.opacity(0.2) : Color.red.opacity(0.2))
                             .cornerRadius(4)
                     }
@@ -196,15 +196,15 @@ struct SystemIntegrationView: View {
                         if systemIntegration.isShortcutsEnabled {
                             Text("Available")
                                 .font(.caption)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
+                                .padding(.horizontal, Spacing.small)
+                                .padding(.vertical, Spacing.xsmall)
                                 .background(Color.green.opacity(0.2))
                                 .cornerRadius(4)
                         } else {
                             Text("macOS 13+ Required")
                                 .font(.caption)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
+                                .padding(.horizontal, Spacing.small)
+                                .padding(.vertical, Spacing.xsmall)
                                 .background(Color.orange.opacity(0.2))
                                 .cornerRadius(4)
                         }

--- a/Smith/Views/UIConstants.swift
+++ b/Smith/Views/UIConstants.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+enum Spacing {
+    static let xsmall: CGFloat = 4    // base unit
+    static let small: CGFloat  = 8
+    static let medium: CGFloat = 12
+    static let large: CGFloat  = 16
+}


### PR DESCRIPTION
## Summary
- define `Spacing` enum for common padding units
- apply spacing constants across major views
- standardize padding values to a 4-point grid

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685197084af483218b71f942d621d8cc