### PR TITLE
Fix permissions manager for macOS

### DIFF
--- a/Smith/Core/PermissionsManager.swift
+++ b/Smith/Core/PermissionsManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import Combine
 import Cocoa
 
 /// Handles requesting sensitive permissions and tracking authorization status.
@@ -21,7 +22,7 @@ class PermissionsManager: ObservableObject {
     }
 
     private func requestMicrophoneAccess() {
-        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
             Task { @MainActor in
                 self.microphoneAuthorized = granted
                 if !granted {


### PR DESCRIPTION
## Summary
- import Combine in `PermissionsManager`
- use `AVCaptureDevice` to request microphone permission on macOS

## Testing
- `swiftc Smith/Core/PermissionsManager.swift -c -o /tmp/perm.o` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_6851a1599e1883219d81fe47459cb455