### PR TITLE
Add memory and network views

### DIFF
--- a/Smith/Views/MemoryView.swift
+++ b/Smith/Views/MemoryView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+struct MemoryView: View {
+    @StateObject private var memoryMonitor = MemoryMonitor()
+    @EnvironmentObject private var smithAgent: SmithAgent
+
+    private var usagePercentage: Double {
+        guard memoryMonitor.totalMemory > 0 else { return 0 }
+        let pct = Double(memoryMonitor.usedMemory) / Double(memoryMonitor.totalMemory) * 100
+        return pct
+    }
+
+    private var usageColor: Color {
+        switch usagePercentage {
+        case ..<60: return .green
+        case ..<80: return .yellow
+        case ..<90: return .orange
+        default: return .red
+        }
+    }
+
+    private func byteString(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .binary)
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            VStack(spacing: 6) {
+                HStack {
+                    Text("Memory Monitor")
+                        .font(.callout)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                    Spacer()
+                    Button(memoryMonitor.isMonitoring ? "Stop" : "Start") {
+                        if memoryMonitor.isMonitoring {
+                            memoryMonitor.stopMonitoring()
+                        } else {
+                            memoryMonitor.startMonitoring()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+                }
+
+                HStack(spacing: 8) {
+                    ZStack {
+                        Circle()
+                            .stroke(.gray.opacity(0.3), lineWidth: 3)
+                            .frame(width: 40, height: 40)
+
+                        Circle()
+                            .trim(from: 0, to: min(usagePercentage / 100, 1))
+                            .stroke(usageColor, lineWidth: 3)
+                            .frame(width: 40, height: 40)
+                            .rotationEffect(.degrees(-90))
+                            .animation(.easeInOut, value: usagePercentage)
+
+                        Text("\(Int(usagePercentage))%")
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Used: \(byteString(memoryMonitor.usedMemory))")
+                            .font(.caption2)
+                            .foregroundColor(.white)
+                        Text("Free: \(byteString(memoryMonitor.freeMemory))")
+                            .font(.caption2)
+                            .foregroundColor(.white)
+                    }
+                    Spacer()
+                }
+            }
+            .padding(Spacing.small)
+            .background(.gray.opacity(0.1))
+
+            ScrollView(showsIndicators: false) {
+                if !memoryMonitor.topMemoryProcesses.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack {
+                            Text("Top Processes")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundColor(.white)
+                            Spacer()
+                            Button("Ask") { askAboutProcesses() }
+                                .buttonStyle(.bordered)
+                                .controlSize(.mini)
+                        }
+                        ForEach(memoryMonitor.topMemoryProcesses.prefix(5)) { process in
+                            MemoryProcessRowView(process: process)
+                        }
+                    }
+                    .padding(.horizontal, Spacing.small)
+                }
+            }
+            .frame(maxHeight: 80)
+        }
+        .background(.black)
+        .frame(maxHeight: 200)
+        .onAppear { memoryMonitor.startMonitoring() }
+        .onDisappear { memoryMonitor.stopMonitoring() }
+    }
+
+    private func askAboutProcesses() {
+        let processes = memoryMonitor.topMemoryProcesses.prefix(5).map { "\($0.displayName): \(Int($0.memoryMB)) MB" }.joined(separator: "\n")
+        Task {
+            await smithAgent.sendMessage("Which apps are consuming the most memory?\n\n\(processes)")
+        }
+    }
+}
+
+struct MemoryProcessRowView: View {
+    let process: MemoryProcessInfo
+
+    var body: some View {
+        HStack {
+            Text(process.displayName)
+                .foregroundColor(.white)
+            Spacer()
+            Text("\(Int(process.memoryMB)) MB")
+                .foregroundColor(process.statusColor)
+        }
+        .font(.caption2)
+    }
+}
+
+#Preview {
+    MemoryView()
+        .environmentObject(SmithAgent())
+}

--- a/Smith/Views/NetworkView.swift
+++ b/Smith/Views/NetworkView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct NetworkView: View {
+    @StateObject private var networkMonitor = NetworkMonitor()
+
+    private func speedString(_ value: Double) -> String {
+        String(format: "%.1f Mbps", value)
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            VStack(spacing: 6) {
+                HStack {
+                    Text("Network Monitor")
+                        .font(.callout)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                    Spacer()
+                    Button(networkMonitor.isMonitoring ? "Stop" : "Start") {
+                        if networkMonitor.isMonitoring {
+                            networkMonitor.stopMonitoring()
+                        } else {
+                            networkMonitor.startMonitoring()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+                }
+
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(networkMonitor.networkQuality.color)
+                        .frame(width: 8, height: 8)
+
+                    Text(networkMonitor.connectionType.rawValue)
+                        .font(.caption2)
+                        .foregroundColor(.white)
+
+                    Spacer()
+
+                    Text(speedString(networkMonitor.downloadSpeed))
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                }
+            }
+            .padding(Spacing.small)
+            .background(.gray.opacity(0.1))
+
+            Spacer()
+        }
+        .background(.black)
+        .frame(maxHeight: 120)
+        .onAppear { networkMonitor.startMonitoring() }
+        .onDisappear { networkMonitor.stopMonitoring() }
+    }
+}
+
+#Preview {
+    NetworkView()
+}


### PR DESCRIPTION
## Summary
- implement `MemoryView` and `NetworkView`
- show memory and network cards in the main view
- integrate monitors with start/stop functions
- extend `SystemMonitorView` with new cases

## Testing
- `swiftc Smith/Views/MemoryView.swift -o /tmp/mvtest` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68519f82fe00832184a80bd734729935