### PR TITLE
Improve color accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Smith follows Apple's design principles while prioritizing system intelligence:
 - **Unobtrusive Monitoring** - Comprehensive awareness without impacting performance
 - **Intuitive Interface** - Complex system data presented simply
 - **Contextual Intelligence** - Understanding the relationships between system components
+- **Accessible Colors** - Uses system colors (`Color.primary`, `Color.secondary`) for legible high-contrast UI
 - **Proactive Assistance** - Anticipating needs before problems occur
 - **Privacy Respect** - Complete system knowledge with zero data collection
 

--- a/Smith/Core/FloatingPanelManager.swift
+++ b/Smith/Core/FloatingPanelManager.swift
@@ -363,7 +363,7 @@ struct FloatingCPUMonitorView: View {
                 GeometryReader { geometry in
                     ZStack(alignment: .leading) {
                         Rectangle()
-                            .fill(.gray.opacity(0.2))
+                            .fill(Color.secondary.opacity(0.2))
                             .frame(height: 8)
                             .clipShape(Capsule())
                         
@@ -391,7 +391,7 @@ struct FloatingCPUMonitorView: View {
                         }
                         .padding(.vertical, 4)
                         .frame(maxWidth: .infinity)
-                        .background(Color.gray.opacity(0.1), in: RoundedRectangle(cornerRadius: 4))
+                        .background(Color.panelBackground, in: RoundedRectangle(cornerRadius: 4))
                     }
                 }
             }
@@ -551,7 +551,7 @@ struct FloatingAIChatView: View {
                             } else {
                                 Text(message.content)
                                     .padding(8)
-                                    .background(.gray.opacity(0.2), in: RoundedRectangle(cornerRadius: 8))
+                                    .background(Color.secondary.opacity(0.2), in: RoundedRectangle(cornerRadius: 8))
                                     .foregroundColor(.primary)
                                 Spacer()
                             }

--- a/Smith/Views/BackgroundSettingsView.swift
+++ b/Smith/Views/BackgroundSettingsView.swift
@@ -370,7 +370,7 @@ struct BackgroundStatsView: View {
                     Spacer()
                 }
                 .padding()
-                .background(Color.gray.opacity(0.1))
+                .background(Color.panelBackground)
                 .cornerRadius(8)
             }
         }

--- a/Smith/Views/BatteryView.swift
+++ b/Smith/Views/BatteryView.swift
@@ -19,7 +19,7 @@ struct BatteryView: View {
                     Text("Battery Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -57,7 +57,7 @@ struct BatteryView: View {
                         Text("\(Int(batteryMonitor.batteryLevel))%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         
                         // Battery tip
                         RoundedRectangle(cornerRadius: 1)
@@ -74,7 +74,7 @@ struct BatteryView: View {
                                 .font(.caption2)
                             Text("Status: \(batteryMonitor.batteryState.description)")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                         }
                         
                         HStack {
@@ -97,7 +97,7 @@ struct BatteryView: View {
                 }
             }
             .padding(Spacing.small)
-            .background(.gray.opacity(0.1))
+            .background(Color.panelBackground)
             
             // Ultra-Compact Power Sources and Tips
             ScrollView(showsIndicators: false) {
@@ -108,7 +108,7 @@ struct BatteryView: View {
                             Text("Power Sources")
                                 .font(.caption)
                                 .fontWeight(.medium)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                             
                             ForEach(batteryMonitor.powerSources.prefix(2), id: \.name) { source in
                                 UltraCompactPowerSourceView(source: source)
@@ -122,7 +122,7 @@ struct BatteryView: View {
                         Text("Optimization Tips")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         
                         VStack(alignment: .leading, spacing: 2) {
                             UltraCompactTipView(icon: "lightbulb", title: "Reduce Brightness")
@@ -176,7 +176,7 @@ struct PowerSourceRowView: View {
         HStack {
             VStack(alignment: .leading) {
                 Text(source.name)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .fontWeight(.medium)
                 
                 Text(source.type)
@@ -189,7 +189,7 @@ struct PowerSourceRowView: View {
             VStack(alignment: .trailing) {
                 if source.maxCapacity > 0 {
                     Text("\(source.currentCapacity)/\(source.maxCapacity)")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                         .font(.caption)
                 }
                 
@@ -200,7 +200,7 @@ struct PowerSourceRowView: View {
         }
         .padding(.vertical, Spacing.xsmall)
         .padding(.horizontal, Spacing.small)
-        .background(.gray.opacity(0.1))
+        .background(Color.panelBackground)
         .cornerRadius(8)
     }
 }
@@ -218,7 +218,7 @@ struct TipRowView: View {
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .fontWeight(.medium)
                 
                 Text(description)
@@ -240,7 +240,7 @@ struct CompactPowerSourceView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(source.name)
                     .font(.caption)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .fontWeight(.medium)
                 
                 Text(source.type)
@@ -254,7 +254,7 @@ struct CompactPowerSourceView: View {
                 if source.maxCapacity > 0 {
                     Text("\(source.currentCapacity)/\(source.maxCapacity)")
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                 }
                 
                 Text(source.batteryState.description)
@@ -264,7 +264,7 @@ struct CompactPowerSourceView: View {
         }
         .padding(.vertical, Spacing.xsmall)
         .padding(.horizontal, Spacing.small)
-        .background(.gray.opacity(0.1))
+        .background(Color.panelBackground)
         .cornerRadius(4)
     }
 }
@@ -282,7 +282,7 @@ struct CompactTipView: View {
             
             Text(title)
                 .font(.caption)
-                .foregroundColor(.white)
+                .foregroundColor(Color.primary)
                 .fontWeight(.medium)
             
             Spacer()
@@ -298,7 +298,7 @@ struct UltraCompactPowerSourceView: View {
         HStack {
             Text(source.name)
                 .font(.caption2)
-                .foregroundColor(.white)
+                .foregroundColor(Color.primary)
                 .fontWeight(.medium)
             
             Spacer()
@@ -306,7 +306,7 @@ struct UltraCompactPowerSourceView: View {
             if source.maxCapacity > 0 {
                 Text("\(source.currentCapacity)/\(source.maxCapacity)")
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
             }
             
             Text(source.batteryState.description)
@@ -315,7 +315,7 @@ struct UltraCompactPowerSourceView: View {
         }
         .padding(.vertical, Spacing.xsmall)
         .padding(.horizontal, Spacing.xsmall)
-        .background(.gray.opacity(0.1))
+        .background(Color.panelBackground)
         .cornerRadius(3)
     }
 }
@@ -333,7 +333,7 @@ struct UltraCompactTipView: View {
             
             Text(title)
                 .font(.caption2)
-                .foregroundColor(.white)
+                .foregroundColor(Color.primary)
                 .fontWeight(.medium)
             
             Spacer()

--- a/Smith/Views/CPUView.swift
+++ b/Smith/Views/CPUView.swift
@@ -19,7 +19,7 @@ struct CPUView: View {
                     Text("CPU Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -52,7 +52,7 @@ struct CPUView: View {
                             Text("\(Int(cpuMonitor.cpuUsage))%")
                                 .font(.caption2)
                                 .fontWeight(.bold)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                         }
                     }
                     
@@ -63,7 +63,7 @@ struct CPUView: View {
                                 .frame(width: 4, height: 4)
                             Text("Usage: \(String(format: "%.1f", cpuMonitor.cpuUsage))%")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                         }
                         
                         HStack {
@@ -72,7 +72,7 @@ struct CPUView: View {
                                 .frame(width: 4, height: 4)
                             Text("Processes: \(cpuMonitor.processes.count)")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                         }
                         
                         Button("Analyze CPU") {
@@ -87,7 +87,7 @@ struct CPUView: View {
                 }
             }
             .padding(Spacing.small)
-            .background(.gray.opacity(0.1))
+            .background(Color.panelBackground)
             
             // Ultra-Compact Process List
             VStack(alignment: .leading, spacing: 2) {
@@ -95,7 +95,7 @@ struct CPUView: View {
                     Text("Top Processes")
                         .font(.caption)
                         .fontWeight(.medium)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -185,7 +185,7 @@ struct ProcessRowView: View {
         HStack {
             VStack(alignment: .leading) {
                 Text(process.displayName)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                 
                 Text("PID: \(process.pid)")
@@ -233,7 +233,7 @@ struct CompactProcessRowView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(process.displayName)
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                 
                 Text("PID: \(process.pid)")
@@ -267,7 +267,7 @@ struct CompactProcessRowView: View {
         }
         .padding(.vertical, Spacing.xsmall)
         .padding(.horizontal, Spacing.xsmall)
-        .background(.gray.opacity(0.05), in: RoundedRectangle(cornerRadius: 4))
+        .background(Color.secondary.opacity(0.05), in: RoundedRectangle(cornerRadius: 4))
         .contentShape(Rectangle())
         .onTapGesture {
             onTap()

--- a/Smith/Views/ChatView.swift
+++ b/Smith/Views/ChatView.swift
@@ -21,7 +21,7 @@ struct ChatView: View {
                     Text("Chat with Smith")
                         .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Text("Your AI coding assistant")
                         .font(.caption)
@@ -178,7 +178,7 @@ struct ModernMessageBubble: View {
                 if message.isUser {
                     Text(message.content)
                         .font(.body)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                         .padding()
                         .background(
                             .blue.opacity(0.2),
@@ -191,7 +191,7 @@ struct ModernMessageBubble: View {
                 } else {
                     Text(message.content)
                         .font(.body)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                         .padding()
                 }
             }
@@ -284,7 +284,7 @@ struct FocusedFileCard: View {
                 Text(file.name)
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
             }
             
@@ -339,7 +339,7 @@ struct OptimizedMessageBubble: View {
                 // Message Content
                 Text(message.content)
                     .font(.subheadline)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .padding(.horizontal, Spacing.medium)
                     .padding(.vertical, Spacing.small)
                     .background(
@@ -434,7 +434,7 @@ struct CompactFocusedFileCard: View {
                 Text(file.name)
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
             }
             

--- a/Smith/Views/Color+Theme.swift
+++ b/Smith/Views/Color+Theme.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+extension Color {
+    /// Background color for panels and containers, adjusts with system appearance
+    static var panelBackground: Color {
+        Color.secondary.opacity(0.1)
+    }
+}

--- a/Smith/Views/DiskView.swift
+++ b/Smith/Views/DiskView.swift
@@ -55,7 +55,7 @@ struct DiskView: View {
                     .truncationMode(.middle)
             }
             .padding(Spacing.small)
-            .background(.gray.opacity(0.1))
+            .background(Color.panelBackground)
             
             // Ultra-Compact File browser with info panel
             HStack(spacing: 4) {
@@ -113,7 +113,7 @@ struct DiskView: View {
                                 VStack(alignment: .leading, spacing: 1) {
                                     Text(selectedItem.name)
                                         .font(.caption2)
-                                        .foregroundColor(.white)
+                                        .foregroundColor(Color.primary)
                                         .lineLimit(2)
                                     
                                     Text(selectedItem.isDirectory ? "Folder" : "File")
@@ -153,7 +153,7 @@ struct DiskView: View {
                     }
                 }
                 .frame(width: 100)
-                .background(.gray.opacity(0.05))
+                .background(Color.secondary.opacity(0.05))
             }
         }
         .background(.black)
@@ -197,7 +197,7 @@ struct FileRowView: View {
             
             VStack(alignment: .leading) {
                 Text(item.name)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {
@@ -238,7 +238,7 @@ struct CompactFileRowView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.name)
                     .font(.caption)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {
@@ -279,7 +279,7 @@ struct UltraCompactFileRowView: View {
             VStack(alignment: .leading, spacing: 0) {
                 Text(item.name)
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -114,7 +114,7 @@ struct MainView: View {
                             .font(.callout)
                             .fontWeight(.bold)
                             .fontDesign(.monospaced)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         
                         Spacer()
                         
@@ -223,7 +223,7 @@ struct MainView: View {
                 .overlay(
                     Rectangle()
                         .frame(height: 0.5)
-                        .foregroundColor(.gray.opacity(0.2)),
+                        .foregroundColor(Color.secondary.opacity(0.2)),
                     alignment: .bottom
                 )
                 
@@ -240,7 +240,7 @@ struct MainView: View {
                                 Text(selectedSystemView.title)
                                     .font(.headline)
                                     .fontWeight(.semibold)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(Color.primary)
                                 
                                 Text(selectedSystemView.description)
                                     .font(.caption2)
@@ -326,7 +326,7 @@ struct MainView: View {
                             .font(.callout)
                             .fontWeight(.bold)
                             .fontDesign(.monospaced)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         
                         Text("Your intelligent assistant")
                             .font(.caption2)
@@ -382,7 +382,7 @@ struct MainView: View {
                 .overlay(
                     Rectangle()
                         .frame(height: 0.3)
-                        .foregroundColor(.gray.opacity(0.2)),
+                        .foregroundColor(Color.secondary.opacity(0.2)),
                     alignment: .bottom
                 )
                 
@@ -514,7 +514,7 @@ struct CompactAutomationSection: View {
                     Text("System Automation")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -786,7 +786,7 @@ struct CompactSystemCard: View {
                 Text(value)
                     .font(.caption2)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
@@ -799,7 +799,7 @@ struct CompactSystemCard: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6)
-                    .stroke(isActive ? color.opacity(0.5) : .gray.opacity(0.1), lineWidth: isActive ? 1 : 0.5)
+                    .stroke(isActive ? color.opacity(0.5) : Color.secondary.opacity(0.1), lineWidth: isActive ? 1 : 0.5)
             )
             .scaleEffect(isActive ? 1.05 : 1.0)
             .animation(.easeInOut(duration: 0.15), value: isActive)
@@ -825,7 +825,7 @@ struct CompactCPUSection: View {
                     Text("Performance")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -895,7 +895,7 @@ struct CompactBatterySection: View {
                     Text("Battery Health")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     
@@ -930,7 +930,7 @@ struct CompactBatterySection: View {
                         Text("\(safeBatteryLevel)%")
                             .font(.callout)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         
                         Text("4h 32m remaining")
                             .font(.caption2)
@@ -989,7 +989,7 @@ struct CompactDiskSection: View {
                     Text("Storage Usage")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
 
                     Spacer()
 
@@ -1002,7 +1002,7 @@ struct CompactDiskSection: View {
                 HStack(spacing: 8) {
                     ZStack {
                         Circle()
-                            .stroke(.gray.opacity(0.2), lineWidth: 3)
+                            .stroke(Color.secondary.opacity(0.2), lineWidth: 3)
                             .frame(width: 36, height: 36)
 
                         Circle()
@@ -1015,14 +1015,14 @@ struct CompactDiskSection: View {
                         Text("\(safeDiskUsage)%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                     }
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(formattedUsedSpace) used")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
 
                         Text("\(formattedAvailableSpace) available")
                             .font(.caption2)
@@ -1081,7 +1081,7 @@ struct EnhancedIntegrationSection: View {
                     Text("System Integration")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     
                     Spacer()
                     

--- a/Smith/Views/MemoryView.swift
+++ b/Smith/Views/MemoryView.swift
@@ -30,7 +30,7 @@ struct MemoryView: View {
                     Text("Memory Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     Spacer()
                     Button(memoryMonitor.isMonitoring ? "Stop" : "Start") {
                         if memoryMonitor.isMonitoring {
@@ -59,22 +59,22 @@ struct MemoryView: View {
                         Text("\(Int(usagePercentage))%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                     }
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Used: \(byteString(memoryMonitor.usedMemory))")
                             .font(.caption2)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                         Text("Free: \(byteString(memoryMonitor.freeMemory))")
                             .font(.caption2)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.primary)
                     }
                     Spacer()
                 }
             }
             .padding(Spacing.small)
-            .background(.gray.opacity(0.1))
+            .background(Color.panelBackground)
 
             ScrollView(showsIndicators: false) {
                 if !memoryMonitor.topMemoryProcesses.isEmpty {
@@ -83,7 +83,7 @@ struct MemoryView: View {
                             Text("Top Processes")
                                 .font(.caption)
                                 .fontWeight(.medium)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.primary)
                             Spacer()
                             Button("Ask") { askAboutProcesses() }
                                 .buttonStyle(.bordered)
@@ -118,7 +118,7 @@ struct MemoryProcessRowView: View {
     var body: some View {
         HStack {
             Text(process.displayName)
-                .foregroundColor(.white)
+                .foregroundColor(Color.primary)
             Spacer()
             Text("\(Int(process.memoryMB)) MB")
                 .foregroundColor(process.statusColor)

--- a/Smith/Views/NetworkView.swift
+++ b/Smith/Views/NetworkView.swift
@@ -14,7 +14,7 @@ struct NetworkView: View {
                     Text("Network Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                     Spacer()
                     Button(networkMonitor.isMonitoring ? "Stop" : "Start") {
                         if networkMonitor.isMonitoring {
@@ -34,17 +34,17 @@ struct NetworkView: View {
 
                     Text(networkMonitor.connectionType.rawValue)
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
 
                     Spacer()
 
                     Text(speedString(networkMonitor.downloadSpeed))
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.primary)
                 }
             }
             .padding(Spacing.small)
-            .background(.gray.opacity(0.1))
+            .background(Color.panelBackground)
 
             Spacer()
         }

--- a/Smith/Views/SystemIntegrationView.swift
+++ b/Smith/Views/SystemIntegrationView.swift
@@ -311,7 +311,7 @@ struct URLSchemeTestView: View {
                         .font(.caption)
                         .fontDesign(.monospaced)
                         .padding()
-                        .background(Color.gray.opacity(0.1))
+                        .background(Color.panelBackground)
                         .cornerRadius(8)
                 }
             }


### PR DESCRIPTION
## Summary
- use `Color.primary` for text instead of fixed white
- add `Color.panelBackground` helper using `Color.secondary`
- apply `panelBackground` throughout to replace gray backgrounds
- document accessible colors in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852526014888321a2f01c2146d3d0a6