### PR TITLE
Enable dynamic type scaling

### DIFF
--- a/Smith/Views/ChatView.swift
+++ b/Smith/Views/ChatView.swift
@@ -126,6 +126,7 @@ struct ChatView: View {
             .background(.black.opacity(0.1))
         }
         .background(.black)
+        .dynamicTypeSize(.medium ... .accessibility3)
         .onAppear {
             isTextFieldFocused = true
         }
@@ -338,7 +339,7 @@ struct OptimizedMessageBubble: View {
                 
                 // Message Content
                 Text(message.content)
-                    .font(.subheadline)
+                    .font(Font.body)
                     .foregroundColor(.white)
                     .padding(.horizontal, Spacing.medium)
                     .padding(.vertical, Spacing.small)

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -394,6 +394,7 @@ struct MainView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .background(.black)
+        .dynamicTypeSize(.medium ... .accessibility3)
         .sheet(isPresented: $showingSettings) {
             EnhancedSettingsView()
                 .environmentObject(automationManager)


### PR DESCRIPTION
## Summary
- support Dynamic Type in ChatView and MainView
- use `Font.body` for message text

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852525b2f4c8321b6c8b6b0f9cac75f