### PR TITLE
Add dark mode preference and adaptive colors

### DIFF
--- a/Smith/ContentView.swift
+++ b/Smith/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     var body: some View {
         ChatView()
             .environmentObject(smithAgent)
-            .background(.black)
+            .background(Color(.windowBackgroundColor))
     }
 }
 

--- a/Smith/SmithApp.swift
+++ b/Smith/SmithApp.swift
@@ -15,6 +15,7 @@ struct SmithApp: App {
     @StateObject private var smithAgent = SmithAgent()
     @StateObject private var launchAgentManager = LaunchAgentManager()
     @StateObject private var backgroundService = BackgroundMonitorService()
+    @AppStorage("smith.darkMode") private var darkMode = false
     
     var body: some Scene {
         WindowGroup {
@@ -22,7 +23,7 @@ struct SmithApp: App {
                 .environmentObject(smithAgent)
                 .environmentObject(launchAgentManager)
                 .environmentObject(backgroundService)
-                .preferredColorScheme(.dark)
+                .preferredColorScheme(darkMode ? .dark : .light)
                 .background(.ultraThinMaterial)
                 .onOpenURL { url in
                     handleSmithURL(url)

--- a/Smith/Views/BatteryView.swift
+++ b/Smith/Views/BatteryView.swift
@@ -19,7 +19,7 @@ struct BatteryView: View {
                     Text("Battery Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -57,7 +57,7 @@ struct BatteryView: View {
                         Text("\(Int(batteryMonitor.batteryLevel))%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         
                         // Battery tip
                         RoundedRectangle(cornerRadius: 1)
@@ -74,7 +74,7 @@ struct BatteryView: View {
                                 .font(.caption2)
                             Text("Status: \(batteryMonitor.batteryState.description)")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                         }
                         
                         HStack {
@@ -108,7 +108,7 @@ struct BatteryView: View {
                             Text("Power Sources")
                                 .font(.caption)
                                 .fontWeight(.medium)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                             
                             ForEach(batteryMonitor.powerSources.prefix(2), id: \.name) { source in
                                 UltraCompactPowerSourceView(source: source)
@@ -122,7 +122,7 @@ struct BatteryView: View {
                         Text("Optimization Tips")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         
                         VStack(alignment: .leading, spacing: 2) {
                             UltraCompactTipView(icon: "lightbulb", title: "Reduce Brightness")
@@ -135,7 +135,7 @@ struct BatteryView: View {
             }
             .frame(maxHeight: 80)
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .frame(maxHeight: 180)
     }
     
@@ -176,7 +176,7 @@ struct PowerSourceRowView: View {
         HStack {
             VStack(alignment: .leading) {
                 Text(source.name)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .fontWeight(.medium)
                 
                 Text(source.type)
@@ -189,7 +189,7 @@ struct PowerSourceRowView: View {
             VStack(alignment: .trailing) {
                 if source.maxCapacity > 0 {
                     Text("\(source.currentCapacity)/\(source.maxCapacity)")
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                         .font(.caption)
                 }
                 
@@ -218,7 +218,7 @@ struct TipRowView: View {
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .fontWeight(.medium)
                 
                 Text(description)
@@ -240,7 +240,7 @@ struct CompactPowerSourceView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(source.name)
                     .font(.caption)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .fontWeight(.medium)
                 
                 Text(source.type)
@@ -254,7 +254,7 @@ struct CompactPowerSourceView: View {
                 if source.maxCapacity > 0 {
                     Text("\(source.currentCapacity)/\(source.maxCapacity)")
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                 }
                 
                 Text(source.batteryState.description)
@@ -282,7 +282,7 @@ struct CompactTipView: View {
             
             Text(title)
                 .font(.caption)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .fontWeight(.medium)
             
             Spacer()
@@ -298,7 +298,7 @@ struct UltraCompactPowerSourceView: View {
         HStack {
             Text(source.name)
                 .font(.caption2)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .fontWeight(.medium)
             
             Spacer()
@@ -306,7 +306,7 @@ struct UltraCompactPowerSourceView: View {
             if source.maxCapacity > 0 {
                 Text("\(source.currentCapacity)/\(source.maxCapacity)")
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
             }
             
             Text(source.batteryState.description)
@@ -333,7 +333,7 @@ struct UltraCompactTipView: View {
             
             Text(title)
                 .font(.caption2)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
                 .fontWeight(.medium)
             
             Spacer()

--- a/Smith/Views/CPUView.swift
+++ b/Smith/Views/CPUView.swift
@@ -19,7 +19,7 @@ struct CPUView: View {
                     Text("CPU Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -52,7 +52,7 @@ struct CPUView: View {
                             Text("\(Int(cpuMonitor.cpuUsage))%")
                                 .font(.caption2)
                                 .fontWeight(.bold)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                         }
                     }
                     
@@ -63,7 +63,7 @@ struct CPUView: View {
                                 .frame(width: 4, height: 4)
                             Text("Usage: \(String(format: "%.1f", cpuMonitor.cpuUsage))%")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                         }
                         
                         HStack {
@@ -72,7 +72,7 @@ struct CPUView: View {
                                 .frame(width: 4, height: 4)
                             Text("Processes: \(cpuMonitor.processes.count)")
                                 .font(.caption2)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                         }
                         
                         Button("Analyze CPU") {
@@ -95,7 +95,7 @@ struct CPUView: View {
                     Text("Top Processes")
                         .font(.caption)
                         .fontWeight(.medium)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -122,7 +122,7 @@ struct CPUView: View {
             }
             .background(.black.opacity(0.02))
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .frame(maxHeight: 220)
         .onAppear {
             Task {
@@ -185,7 +185,7 @@ struct ProcessRowView: View {
         HStack {
             VStack(alignment: .leading) {
                 Text(process.displayName)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 Text("PID: \(process.pid)")
@@ -233,7 +233,7 @@ struct CompactProcessRowView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(process.displayName)
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 Text("PID: \(process.pid)")

--- a/Smith/Views/ChatView.swift
+++ b/Smith/Views/ChatView.swift
@@ -21,7 +21,7 @@ struct ChatView: View {
                     Text("Chat with Smith")
                         .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Text("Your AI coding assistant")
                         .font(.caption)
@@ -125,7 +125,7 @@ struct ChatView: View {
             .padding()
             .background(.black.opacity(0.1))
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .onAppear {
             isTextFieldFocused = true
         }
@@ -178,7 +178,7 @@ struct ModernMessageBubble: View {
                 if message.isUser {
                     Text(message.content)
                         .font(.body)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                         .padding()
                         .background(
                             .blue.opacity(0.2),
@@ -191,7 +191,7 @@ struct ModernMessageBubble: View {
                 } else {
                     Text(message.content)
                         .font(.body)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                         .padding()
                 }
             }
@@ -284,7 +284,7 @@ struct FocusedFileCard: View {
                 Text(file.name)
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
             }
             
@@ -339,7 +339,7 @@ struct OptimizedMessageBubble: View {
                 // Message Content
                 Text(message.content)
                     .font(.subheadline)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .padding(.horizontal, Spacing.medium)
                     .padding(.vertical, Spacing.small)
                     .background(
@@ -434,7 +434,7 @@ struct CompactFocusedFileCard: View {
                 Text(file.name)
                     .font(.caption)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
             }
             
@@ -460,5 +460,5 @@ struct CompactFocusedFileCard: View {
 #Preview {
     ChatView()
         .environmentObject(SmithAgent())
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
 }

--- a/Smith/Views/DiskView.swift
+++ b/Smith/Views/DiskView.swift
@@ -113,7 +113,7 @@ struct DiskView: View {
                                 VStack(alignment: .leading, spacing: 1) {
                                     Text(selectedItem.name)
                                         .font(.caption2)
-                                        .foregroundColor(.white)
+                                        .foregroundColor(.primary)
                                         .lineLimit(2)
                                     
                                     Text(selectedItem.isDirectory ? "Folder" : "File")
@@ -156,7 +156,7 @@ struct DiskView: View {
                 .background(.gray.opacity(0.05))
             }
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .frame(maxHeight: 200)
     }
     
@@ -192,12 +192,12 @@ struct FileRowView: View {
     var body: some View {
         HStack {
             Image(systemName: item.icon)
-                .foregroundColor(item.isDirectory ? .cyan : .white)
+                .foregroundColor(item.isDirectory ? .cyan : .primary)
                 .frame(width: 20)
             
             VStack(alignment: .leading) {
                 Text(item.name)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {
@@ -231,14 +231,14 @@ struct CompactFileRowView: View {
     var body: some View {
         HStack {
             Image(systemName: item.icon)
-                .foregroundColor(item.isDirectory ? .cyan : .white)
+                .foregroundColor(item.isDirectory ? .cyan : .primary)
                 .font(.caption)
                 .frame(width: 12)
             
             VStack(alignment: .leading, spacing: 1) {
                 Text(item.name)
                     .font(.caption)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {
@@ -272,14 +272,14 @@ struct UltraCompactFileRowView: View {
     var body: some View {
         HStack {
             Image(systemName: item.icon)
-                .foregroundColor(item.isDirectory ? .cyan : .white)
+                .foregroundColor(item.isDirectory ? .cyan : .primary)
                 .font(.caption2)
                 .frame(width: 10)
             
             VStack(alignment: .leading, spacing: 0) {
                 Text(item.name)
                     .font(.caption2)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                 
                 if !item.isDirectory {

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -114,7 +114,7 @@ struct MainView: View {
                             .font(.callout)
                             .fontWeight(.bold)
                             .fontDesign(.monospaced)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         
                         Spacer()
                         
@@ -240,7 +240,7 @@ struct MainView: View {
                                 Text(selectedSystemView.title)
                                     .font(.headline)
                                     .fontWeight(.semibold)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(.primary)
                                 
                                 Text(selectedSystemView.description)
                                     .font(.caption2)
@@ -326,7 +326,7 @@ struct MainView: View {
                             .font(.callout)
                             .fontWeight(.bold)
                             .fontDesign(.monospaced)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         
                         Text("Your intelligent assistant")
                             .font(.caption2)
@@ -390,10 +390,10 @@ struct MainView: View {
                 ChatView()
                     .environmentObject(smithAgent)
             }
-            .background(.black)
+            .background(Color(.windowBackgroundColor))
         }
         .navigationSplitViewStyle(.balanced)
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .sheet(isPresented: $showingSettings) {
             EnhancedSettingsView()
                 .environmentObject(automationManager)
@@ -514,7 +514,7 @@ struct CompactAutomationSection: View {
                     Text("System Automation")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -786,7 +786,7 @@ struct CompactSystemCard: View {
                 Text(value)
                     .font(.caption2)
                     .fontWeight(.medium)
-                    .foregroundColor(.white)
+                    .foregroundColor(.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
@@ -825,7 +825,7 @@ struct CompactCPUSection: View {
                     Text("Performance")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -895,7 +895,7 @@ struct CompactBatterySection: View {
                     Text("Battery Health")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     
@@ -930,7 +930,7 @@ struct CompactBatterySection: View {
                         Text("\(safeBatteryLevel)%")
                             .font(.callout)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         
                         Text("4h 32m remaining")
                             .font(.caption2)
@@ -989,7 +989,7 @@ struct CompactDiskSection: View {
                     Text("Storage Usage")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
 
                     Spacer()
 
@@ -1015,14 +1015,14 @@ struct CompactDiskSection: View {
                         Text("\(safeDiskUsage)%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                     }
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("\(formattedUsedSpace) used")
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
 
                         Text("\(formattedAvailableSpace) available")
                             .font(.caption2)
@@ -1081,7 +1081,7 @@ struct EnhancedIntegrationSection: View {
                     Text("System Integration")
                         .font(.subheadline)
                         .fontWeight(.semibold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     
                     Spacer()
                     

--- a/Smith/Views/MemoryView.swift
+++ b/Smith/Views/MemoryView.swift
@@ -30,7 +30,7 @@ struct MemoryView: View {
                     Text("Memory Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     Spacer()
                     Button(memoryMonitor.isMonitoring ? "Stop" : "Start") {
                         if memoryMonitor.isMonitoring {
@@ -59,16 +59,16 @@ struct MemoryView: View {
                         Text("\(Int(usagePercentage))%")
                             .font(.caption2)
                             .fontWeight(.bold)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                     }
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Used: \(byteString(memoryMonitor.usedMemory))")
                             .font(.caption2)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                         Text("Free: \(byteString(memoryMonitor.freeMemory))")
                             .font(.caption2)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primary)
                     }
                     Spacer()
                 }
@@ -83,7 +83,7 @@ struct MemoryView: View {
                             Text("Top Processes")
                                 .font(.caption)
                                 .fontWeight(.medium)
-                                .foregroundColor(.white)
+                                .foregroundColor(.primary)
                             Spacer()
                             Button("Ask") { askAboutProcesses() }
                                 .buttonStyle(.bordered)
@@ -98,7 +98,7 @@ struct MemoryView: View {
             }
             .frame(maxHeight: 80)
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .frame(maxHeight: 200)
         .onAppear { memoryMonitor.startMonitoring() }
         .onDisappear { memoryMonitor.stopMonitoring() }
@@ -118,7 +118,7 @@ struct MemoryProcessRowView: View {
     var body: some View {
         HStack {
             Text(process.displayName)
-                .foregroundColor(.white)
+                .foregroundColor(.primary)
             Spacer()
             Text("\(Int(process.memoryMB)) MB")
                 .foregroundColor(process.statusColor)

--- a/Smith/Views/NetworkView.swift
+++ b/Smith/Views/NetworkView.swift
@@ -14,7 +14,7 @@ struct NetworkView: View {
                     Text("Network Monitor")
                         .font(.callout)
                         .fontWeight(.bold)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                     Spacer()
                     Button(networkMonitor.isMonitoring ? "Stop" : "Start") {
                         if networkMonitor.isMonitoring {
@@ -34,13 +34,13 @@ struct NetworkView: View {
 
                     Text(networkMonitor.connectionType.rawValue)
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
 
                     Spacer()
 
                     Text(speedString(networkMonitor.downloadSpeed))
                         .font(.caption2)
-                        .foregroundColor(.white)
+                        .foregroundColor(.primary)
                 }
             }
             .padding(Spacing.small)
@@ -48,7 +48,7 @@ struct NetworkView: View {
 
             Spacer()
         }
-        .background(.black)
+        .background(Color(.windowBackgroundColor))
         .frame(maxHeight: 120)
         .onAppear { networkMonitor.startMonitoring() }
         .onDisappear { networkMonitor.stopMonitoring() }


### PR DESCRIPTION
## Summary
- control color scheme with `smith.darkMode` AppStorage value
- update backgrounds to follow system theme
- use `.primary` for text colors to support light and dark modes

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68525276528c8321b1c713faf157b111