### PR TITLE
Fix FloatingPanel frame persistence

### DIFF
--- a/Smith/Core/FloatingPanelManager.swift
+++ b/Smith/Core/FloatingPanelManager.swift
@@ -112,7 +112,7 @@ class FloatingPanelManager: ObservableObject {
         defaults.synchronize()
     }
 
-    private func saveWindowFrame(for panelId: String) {
+    fileprivate func saveWindowFrame(for panelId: String) {
         guard let window = windowControllers[panelId]?.window else { return }
         let frameString = NSStringFromRect(window.frame)
         defaults.set(frameString, forKey: "smith.panel.\(panelId).frame")


### PR DESCRIPTION
## Summary
- expose `saveWindowFrame` to `WindowDelegate`

## Testing
- `swiftc -parse Smith/Core/FloatingPanelManager.swift`

------
https://chatgpt.com/codex/tasks/task_e_685254d213588321b52749d9ae76bb26