### PR TITLE
Fix BackgroundIntensity isolation issue

### DIFF
--- a/Smith/Core/AppleScriptSupport.swift
+++ b/Smith/Core/AppleScriptSupport.swift
@@ -257,7 +257,7 @@ class SmithApplication: NSApplication {
     @objc func setBackgroundIntensity(_ intensity: NSString) -> NSString {
         logger.info("AppleScript: setBackgroundIntensity called with: \(intensity)")
         
-        guard LaunchAgentManager.BackgroundIntensity(rawValue: intensity as String) != nil else {
+        guard BackgroundIntensity(rawValue: intensity as String) != nil else {
             return NSString(string: "Invalid intensity level. Use 'minimal', 'balanced', or 'comprehensive'.")
         }
         

--- a/Smith/Core/BackgroundIntensity.swift
+++ b/Smith/Core/BackgroundIntensity.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum BackgroundIntensity: String, CaseIterable, Codable, Sendable {
+    case minimal = "minimal"
+    case medium = "medium"
+    case balanced = "balanced"
+    case comprehensive = "comprehensive"
+
+    var displayName: String {
+        switch self {
+        case .minimal: return "Minimal"
+        case .medium: return "Medium"
+        case .balanced: return "Balanced"
+        case .comprehensive: return "Comprehensive"
+        }
+    }
+
+    var updateInterval: TimeInterval {
+        switch self {
+        case .minimal: return 300 // 5 minutes
+        case .medium: return 120  // 2 minutes
+        case .balanced: return 60  // 1 minute
+        case .comprehensive: return 15 // 15 seconds
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .minimal: return "Basic monitoring every 5 minutes"
+        case .medium: return "Moderate monitoring every 2 minutes"
+        case .balanced: return "Regular monitoring every minute"
+        case .comprehensive: return "Detailed monitoring every 15 seconds"
+        }
+    }
+}

--- a/Smith/Core/BackgroundMonitorService.swift
+++ b/Smith/Core/BackgroundMonitorService.swift
@@ -40,7 +40,7 @@ final class BackgroundMonitorService: ObservableObject {
     private let batteryMonitor: BatteryMonitor
     
     // Background monitoring settings
-    private var intensity: LaunchAgentManager.BackgroundIntensity = .balanced
+    private var intensity: BackgroundIntensity = .balanced
     private var monitoringInterval: TimeInterval = 60
     
     // MARK: - Initialization
@@ -59,7 +59,7 @@ final class BackgroundMonitorService: ObservableObject {
     
     // MARK: - Public Methods
     
-    func startMonitoring(intensity: LaunchAgentManager.BackgroundIntensity = .balanced) {
+    func startMonitoring(intensity: BackgroundIntensity = .balanced) {
         guard !isRunning else { return }
         
         self.intensity = intensity
@@ -132,7 +132,7 @@ final class BackgroundMonitorService: ObservableObject {
             // Parse intensity argument
             if let intensityArg = arguments.first(where: { $0.hasPrefix("--intensity=") }),
                let intensityValue = intensityArg.split(separator: "=").last,
-               let intensity = LaunchAgentManager.BackgroundIntensity(rawValue: String(intensityValue)) {
+               let intensity = BackgroundIntensity(rawValue: String(intensityValue)) {
                 startMonitoring(intensity: intensity)
             } else {
                 startMonitoring(intensity: .balanced)
@@ -319,14 +319,14 @@ struct BackgroundSystemStats: Codable, Sendable {
     let isPluggedIn: Bool
     let intensityRawValue: String
     
-    var intensity: LaunchAgentManager.BackgroundIntensity {
-        return LaunchAgentManager.BackgroundIntensity(rawValue: intensityRawValue) ?? .balanced
+    var intensity: BackgroundIntensity {
+        return BackgroundIntensity(rawValue: intensityRawValue) ?? .balanced
     }
     
     init(timestamp: Date, cpuUsage: Double, cpuTemperature: Double?, 
          memoryUsage: Double, memoryPressure: String, batteryLevel: Double, 
          batteryHealth: Double, isPluggedIn: Bool, 
-         intensity: LaunchAgentManager.BackgroundIntensity) {
+         intensity: BackgroundIntensity) {
         self.timestamp = timestamp
         self.cpuUsage = cpuUsage
         self.cpuTemperature = cpuTemperature

--- a/Smith/Core/LaunchAgentManager.swift
+++ b/Smith/Core/LaunchAgentManager.swift
@@ -31,41 +31,8 @@ final class LaunchAgentManager: ObservableObject {
     private let appName = "Smith"
     
     // MARK: - Background Intensity Levels
-    
-    enum BackgroundIntensity: String, CaseIterable, Codable, Sendable {
-        case minimal = "minimal"
-        case medium = "medium"
-        case balanced = "balanced" 
-        case comprehensive = "comprehensive"
-        
-        var displayName: String {
-            switch self {
-            case .minimal: return "Minimal"
-            case .medium: return "Medium"
-            case .balanced: return "Balanced"
-            case .comprehensive: return "Comprehensive"
-            }
-        }
-        
-        var updateInterval: TimeInterval {
-            switch self {
-            case .minimal: return 300 // 5 minutes
-            case .medium: return 120  // 2 minutes
-            case .balanced: return 60  // 1 minute
-            case .comprehensive: return 15 // 15 seconds
-            }
-        }
-        
-        var description: String {
-            switch self {
-            case .minimal: return "Basic monitoring every 5 minutes"
-            case .medium: return "Moderate monitoring every 2 minutes"
-            case .balanced: return "Regular monitoring every minute"
-            case .comprehensive: return "Detailed monitoring every 15 seconds"
-            }
-        }
-    }
-    
+    // The BackgroundIntensity enum is defined in BackgroundIntensity.swift
+
     // MARK: - Initialization
     
     init() {

--- a/Smith/SmithApp.swift
+++ b/Smith/SmithApp.swift
@@ -71,7 +71,7 @@ struct SmithApp: App {
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .smithBackgroundIntensityChanged)) { notification in
                     if let intensityString = notification.object as? String,
-                       let intensity = LaunchAgentManager.BackgroundIntensity(rawValue: intensityString) {
+                       let intensity = BackgroundIntensity(rawValue: intensityString) {
                         Task {
                             await launchAgentManager.setBackgroundIntensity(intensity)
                         }

--- a/Smith/Views/BackgroundSettingsView.swift
+++ b/Smith/Views/BackgroundSettingsView.swift
@@ -272,7 +272,7 @@ struct IntensitySelector: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(LaunchAgentManager.BackgroundIntensity.allCases, id: \.rawValue) { intensity in
+            ForEach(BackgroundIntensity.allCases, id: \.rawValue) { intensity in
                 HStack {
                     Button {
                         changeIntensity(to: intensity)
@@ -307,7 +307,7 @@ struct IntensitySelector: View {
         }
     }
     
-    private func changeIntensity(to intensity: LaunchAgentManager.BackgroundIntensity) {
+    private func changeIntensity(to intensity: BackgroundIntensity) {
         guard intensity != launchAgent.backgroundIntensity else { return }
         
         isChanging = true


### PR DESCRIPTION
## Summary
- extract `BackgroundIntensity` enum from `LaunchAgentManager`
- replace nested enum references across the app

## Testing
- `swiftc Smith/Core/BackgroundIntensity.swift -o /tmp/test_intensity`

------
https://chatgpt.com/codex/tasks/task_e_685255c56874832195996f3f8002fcff