### PR TITLE
Add network and storage integration

### DIFF
--- a/Smith/Core/IntelligenceEngine.swift
+++ b/Smith/Core/IntelligenceEngine.swift
@@ -24,6 +24,8 @@ class IntelligenceEngine: ObservableObject {
     private weak var cpuMonitor: CPUMonitor?
     private weak var batteryMonitor: BatteryMonitor?
     private weak var memoryMonitor: MemoryMonitor?
+    private weak var networkMonitor: NetworkMonitor?
+    private weak var storageMonitor: StorageMonitor?
     
     // MARK: - Session Intelligence
     private var sessionStartTime: Date = Date()
@@ -46,10 +48,12 @@ class IntelligenceEngine: ObservableObject {
     }
     
     // MARK: - System Monitor Integration
-    func setMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor) {
+    func setMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor, network: NetworkMonitor, storage: StorageMonitor) {
         self.cpuMonitor = cpu
         self.batteryMonitor = battery
         self.memoryMonitor = memory
+        self.networkMonitor = network
+        self.storageMonitor = storage
     }
     
     // MARK: - Real-Time Analysis
@@ -97,7 +101,16 @@ class IntelligenceEngine: ObservableObject {
             batteryLevel: batteryMonitor?.batteryLevel ?? 0.0,
             batteryState: batteryMonitor?.batteryState ?? .unknown,
             powerUsage: batteryMonitor?.powerUsage ?? 0.0,
-            runningApplications: getRunningApplications()
+            runningApplications: getRunningApplications(),
+            networkIsConnected: networkMonitor?.isConnected ?? false,
+            networkConnectionType: networkMonitor?.connectionType ?? .unknown,
+            networkQuality: networkMonitor?.networkQuality ?? .unknown,
+            networkDownloadSpeed: networkMonitor?.downloadSpeed ?? 0.0,
+            networkUploadSpeed: networkMonitor?.uploadSpeed ?? 0.0,
+            networkLatency: networkMonitor?.latency ?? 0.0,
+            diskTotalSpace: storageMonitor?.totalSpace ?? 0,
+            diskUsedSpace: storageMonitor?.usedSpace ?? 0,
+            diskAvailableSpace: storageMonitor?.availableSpace ?? 0
         )
     }
     
@@ -647,6 +660,15 @@ struct SystemSnapshot {
     let batteryState: BatteryState
     let powerUsage: Double
     let runningApplications: [RunningApplication]
+    let networkIsConnected: Bool
+    let networkConnectionType: NetworkMonitor.ConnectionType
+    let networkQuality: NetworkMonitor.NetworkQuality
+    let networkDownloadSpeed: Double
+    let networkUploadSpeed: Double
+    let networkLatency: Double
+    let diskTotalSpace: Int64
+    let diskUsedSpace: Int64
+    let diskAvailableSpace: Int64
 }
 
 struct RunningApplication {

--- a/Smith/Core/SmithAgent.swift
+++ b/Smith/Core/SmithAgent.swift
@@ -394,8 +394,8 @@ class SmithAgent: ObservableObject {
     }
     
     // MARK: - Intelligence Engine Integration
-    func setSystemMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor) {
-        intelligenceEngine.setMonitors(cpu: cpu, battery: battery, memory: memory)
+    func setSystemMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor, network: NetworkMonitor, storage: StorageMonitor) {
+        intelligenceEngine.setMonitors(cpu: cpu, battery: battery, memory: memory, network: network, storage: storage)
     }
     
     func getCurrentSystemInsights() -> [SystemInsight] {

--- a/Smith/Core/SystemAutomationManager.swift
+++ b/Smith/Core/SystemAutomationManager.swift
@@ -27,6 +27,8 @@ class SystemAutomationManager: ObservableObject {
     private var cpuMonitor: CPUMonitor?
     private var batteryMonitor: BatteryMonitor?
     private var memoryMonitor: MemoryMonitor?
+    private var networkMonitor: NetworkMonitor?
+    private var storageMonitor: StorageMonitor?
     private var intelligenceEngine: IntelligenceEngine?
     
     init() {
@@ -36,10 +38,12 @@ class SystemAutomationManager: ObservableObject {
     }
     
     // MARK: - Setup
-    func setMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor, intelligence: IntelligenceEngine) {
+    func setMonitors(cpu: CPUMonitor, battery: BatteryMonitor, memory: MemoryMonitor, network: NetworkMonitor, storage: StorageMonitor, intelligence: IntelligenceEngine) {
         self.cpuMonitor = cpu
         self.batteryMonitor = battery
         self.memoryMonitor = memory
+        self.networkMonitor = network
+        self.storageMonitor = storage
         self.intelligenceEngine = intelligence
     }
     

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -467,8 +467,8 @@ struct MainView: View {
         storageMonitor.startMonitoring()
         
         // Setup integrations
-        smithAgent.setSystemMonitors(cpu: cpuMonitor, battery: batteryMonitor, memory: memoryMonitor)
-        automationManager.setMonitors(cpu: cpuMonitor, battery: batteryMonitor, memory: memoryMonitor, intelligence: smithAgent.intelligenceEngine)
+        smithAgent.setSystemMonitors(cpu: cpuMonitor, battery: batteryMonitor, memory: memoryMonitor, network: networkMonitor, storage: storageMonitor)
+        automationManager.setMonitors(cpu: cpuMonitor, battery: batteryMonitor, memory: memoryMonitor, network: networkMonitor, storage: storageMonitor, intelligence: smithAgent.intelligenceEngine)
         floatingPanelManager.setDependencies(smithAgent: smithAgent, cpuMonitor: cpuMonitor, batteryMonitor: batteryMonitor, memoryMonitor: memoryMonitor)
     }
     


### PR DESCRIPTION
## Summary
- expand monitor registration to include network and storage monitors
- expose new metrics in `SystemSnapshot`
- update MainView to pass new monitors
- update automation manager to store the new monitors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68525314bf54832194cff948f4785030