### PR TITLE
Add network name detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Smith is an intelligent macOS system assistant that monitors, analyzes, and unde
 - **Battery Health** - Power consumption, charging cycles, health metrics, and efficiency tips
 - **Storage Analysis** - Disk usage, file types, large files, and cleanup opportunities
 - **Network Activity** - Bandwidth usage, connections, and network health
+- **Network Name Detection** - Shows the currently connected network or SSID
 - **Thermal Management** - Temperature monitoring and thermal throttling detection
 - **Process Intelligence** - Application behavior, resource consumption, and performance impact
 

--- a/Smith/Core/IntelligenceEngine.swift
+++ b/Smith/Core/IntelligenceEngine.swift
@@ -104,6 +104,7 @@ class IntelligenceEngine: ObservableObject {
             runningApplications: getRunningApplications(),
             networkIsConnected: networkMonitor?.isConnected ?? false,
             networkConnectionType: networkMonitor?.connectionType ?? .unknown,
+            networkName: networkMonitor?.networkName ?? "",
             networkQuality: networkMonitor?.networkQuality ?? .unknown,
             networkDownloadSpeed: networkMonitor?.downloadSpeed ?? 0.0,
             networkUploadSpeed: networkMonitor?.uploadSpeed ?? 0.0,
@@ -662,6 +663,7 @@ struct SystemSnapshot {
     let runningApplications: [RunningApplication]
     let networkIsConnected: Bool
     let networkConnectionType: NetworkMonitor.ConnectionType
+    let networkName: String
     let networkQuality: NetworkMonitor.NetworkQuality
     let networkDownloadSpeed: Double
     let networkUploadSpeed: Double

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -200,7 +200,7 @@ struct MainView: View {
 
                         CompactSystemCard(
                             icon: "wifi",
-                            value: networkMonitor.isConnected ? networkMonitor.connectionType.rawValue : "Off",
+                            value: networkMonitor.isConnected ? (networkMonitor.networkName.isEmpty ? networkMonitor.connectionType.rawValue : "\(networkMonitor.connectionType.rawValue) - \(networkMonitor.networkName)") : "Off",
                             color: networkStatusColor,
                             isActive: selectedSystemView == .network
                         ) {

--- a/Smith/Views/NetworkView.swift
+++ b/Smith/Views/NetworkView.swift
@@ -35,7 +35,11 @@ struct NetworkView: View {
                     Text(networkMonitor.connectionType.rawValue)
                         .font(.caption2)
                         .foregroundColor(Color.primary)
-
+                    if !networkMonitor.networkName.isEmpty {
+                        Text("(\(networkMonitor.networkName))")
+                            .font(.caption2)
+                            .foregroundColor(Color.primary)
+                    }
                     Spacer()
 
                     Text(speedString(networkMonitor.downloadSpeed))


### PR DESCRIPTION
## Summary
- detect network name via CoreWLAN
- surface network name in snapshot model
- display connected network in network and main views
- document capability in README

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68525967b08483218284d71a70bfdc7f