### PR TITLE
Fix PermissionsManager conformance

### DIFF
--- a/Smith/Core/PermissionsManager.swift
+++ b/Smith/Core/PermissionsManager.swift
@@ -6,7 +6,7 @@ import CoreLocation
 
 /// Handles requesting sensitive permissions and tracking authorization status.
 @MainActor
-class PermissionsManager: ObservableObject {
+class PermissionsManager: NSObject, ObservableObject {
     static let shared = PermissionsManager()
 
     @Published var microphoneAuthorized: Bool = false
@@ -16,7 +16,8 @@ class PermissionsManager: ObservableObject {
 
     private let locationManager = CLLocationManager()
 
-    private init() {
+    private override init() {
+        super.init()
         locationManager.delegate = self
     }
 


### PR DESCRIPTION
## Summary
- inherit `NSObject` to conform to `CLLocationManagerDelegate`
- call `super.init()` in initializer

## Testing
- `swiftc Smith/Core/PermissionsManager.swift -emit-object` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_68525e3e9dbc8321bfa287314d1b4919