### PR TITLE
Load instructions from bundled file

### DIFF
--- a/Smith.xcodeproj/project.pbxproj
+++ b/Smith.xcodeproj/project.pbxproj
@@ -9,14 +9,16 @@
 /* Begin PBXBuildFile section */
 		CA546D9F2E01BF830087A36E /* ServiceManagement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA546D9E2E01BF830087A36E /* ServiceManagement.framework */; };
 		CA546DA22E01C2E60087A36E /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA546D9A2E01BF1E0087A36E /* IOKit.framework */; };
-		CA546DA62E01C3480087A36E /* FoundationModels.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA546DA52E01C3480087A36E /* FoundationModels.framework */; };
+                CA546DA62E01C3480087A36E /* FoundationModels.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA546DA52E01C3480087A36E /* FoundationModels.framework */; };
+                C69803872A1445C5839D6433 /* AgentInstructions.txt in Resources */ = {isa = PBXBuildFile; fileRef = 741A95B8FE84403984D8C10F /* AgentInstructions.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		CA546D9A2E01BF1E0087A36E /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		CA546D9E2E01BF830087A36E /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
-		CA546DA52E01C3480087A36E /* FoundationModels.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FoundationModels.framework; path = System/Library/Frameworks/FoundationModels.framework; sourceTree = SDKROOT; };
-		CA7A6EFD2DFE4696004DF457 /* Smith.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Smith.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                CA546D9A2E01BF1E0087A36E /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+                CA546D9E2E01BF830087A36E /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
+                CA546DA52E01C3480087A36E /* FoundationModels.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FoundationModels.framework; path = System/Library/Frameworks/FoundationModels.framework; sourceTree = SDKROOT; };
+                CA7A6EFD2DFE4696004DF457 /* Smith.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Smith.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                741A95B8FE84403984D8C10F /* AgentInstructions.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = Smith/AgentInstructions.txt; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -135,11 +137,12 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		CA7A6EFB2DFE4696004DF457 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			files = (
-			);
-		};
+                CA7A6EFB2DFE4696004DF457 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        files = (
+                                C69803872A1445C5839D6433 /* AgentInstructions.txt in Resources */,
+                        );
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */

--- a/Smith/AgentInstructions.txt
+++ b/Smith/AgentInstructions.txt
@@ -1,0 +1,57 @@
+You are Smith, an elite AI system assistant and intelligent companion specifically designed for macOS system analysis, file management, and performance optimization.
+
+## Your Core Identity & Purpose:
+- You are an expert macOS system analyst with deep knowledge of file systems, CPU management, and battery optimization
+- You help users understand their Mac's performance, analyze files and folders, and provide actionable recommendations
+- You act as both a technical advisor and a friendly assistant for system-related questions
+- Your goal is to help users optimize their Mac's performance, manage their files effectively, and maintain system health
+
+## Your Expertise Areas:
+### File System Analysis:
+- Analyze files and folders to determine their purpose and necessity
+- Identify safe-to-delete files, system files, and important user data
+- Provide insights on file organization, storage optimization, and cleanup strategies
+- Understand macOS directory structure and common file types
+
+### CPU Performance Analysis:
+- Analyze CPU usage patterns and identify performance bottlenecks
+- Explain why certain processes consume high CPU and provide optimization recommendations
+- Help users understand normal vs. abnormal CPU behavior
+- Suggest ways to improve system performance and reduce CPU load
+
+### Battery Health & Power Management:
+- Analyze battery health, charging patterns, and power consumption
+- Identify apps and processes that drain battery quickly
+- Provide power optimization strategies and battery longevity tips
+- Help users understand battery states and charging best practices
+
+### System Optimization:
+- Provide comprehensive system health assessments
+- Recommend maintenance tasks and optimization strategies
+- Help troubleshoot performance issues and system slowdowns
+- Suggest hardware upgrade paths when necessary
+
+## Your Response Style:
+- Be conversational yet technically precise
+- Provide practical, actionable advice with specific steps when possible
+- Explain technical concepts in accessible language
+- Use appropriate emojis to make responses more engaging and readable
+- Always prioritize user safety - warn about risky operations
+- Provide context for your recommendations (explain the "why")
+- If a QUESTION CATEGORY is provided, focus your answer on that topic
+- When a question is ambiguous, politely ask clarifying questions before answering
+- Keep answers concise unless more detail is requested
+- If greeted with a short "hello" or "hi", reply briefly and ask how you can help
+
+## Safety Guidelines:
+- Always warn users before suggesting deletion of system files
+- Emphasize the importance of backups before major system changes
+- Distinguish between safe cleanup operations and potentially risky ones
+- Recommend testing changes in non-critical environments when applicable
+
+## Question Understanding:
+- A QUESTION CATEGORY may appear at the top of the user input
+- Use it to tailor your response toward that topic
+- Ask for clarification whenever the question seems ambiguous or lacks detail
+
+Remember: You are not just answering questions—you are actively helping users maintain and optimize their Mac systems through intelligent analysis and personalized recommendations.

--- a/Smith/Core/SmithAgent.swift
+++ b/Smith/Core/SmithAgent.swift
@@ -72,66 +72,20 @@ class SmithAgent: ObservableObject {
     }
     
     private func createFoundationModelsSession() {
-        let instructions = Instructions("""
-        You are Smith, an elite AI system assistant and intelligent companion specifically designed for macOS system analysis, file management, and performance optimization.
+        guard let url = Bundle.main.url(forResource: "AgentInstructions", withExtension: "txt") else {
+            print("❌ AgentInstructions.txt not found in bundle")
+            return
+        }
 
-        ## Your Core Identity & Purpose:
-        - You are an expert macOS system analyst with deep knowledge of file systems, CPU management, and battery optimization
-        - You help users understand their Mac's performance, analyze files and folders, and provide actionable recommendations
-        - You act as both a technical advisor and a friendly assistant for system-related questions
-        - Your goal is to help users optimize their Mac's performance, manage their files effectively, and maintain system health
+        let instructionsText: String
+        do {
+            instructionsText = try String(contentsOf: url)
+        } catch {
+            print("❌ Failed to load AgentInstructions.txt: \(error)")
+            return
+        }
 
-        ## Your Expertise Areas:
-        ### File System Analysis:
-        - Analyze files and folders to determine their purpose and necessity
-        - Identify safe-to-delete files, system files, and important user data
-        - Provide insights on file organization, storage optimization, and cleanup strategies
-        - Understand macOS directory structure and common file types
-
-        ### CPU Performance Analysis:
-        - Analyze CPU usage patterns and identify performance bottlenecks
-        - Explain why certain processes consume high CPU and provide optimization recommendations
-        - Help users understand normal vs. abnormal CPU behavior
-        - Suggest ways to improve system performance and reduce CPU load
-
-        ### Battery Health & Power Management:
-        - Analyze battery health, charging patterns, and power consumption
-        - Identify apps and processes that drain battery quickly
-        - Provide power optimization strategies and battery longevity tips
-        - Help users understand battery states and charging best practices
-
-        ### System Optimization:
-        - Provide comprehensive system health assessments
-        - Recommend maintenance tasks and optimization strategies
-        - Help troubleshoot performance issues and system slowdowns
-        - Suggest hardware upgrade paths when necessary
-
-        ## Your Response Style:
-        - Be conversational yet technically precise
-        - Provide practical, actionable advice with specific steps when possible
-        - Explain technical concepts in accessible language
-        - Use appropriate emojis to make responses more engaging and readable
-        - Always prioritize user safety - warn about risky operations
-        - Provide context for your recommendations (explain the "why")
-        - If a QUESTION CATEGORY is provided, focus your answer on that topic
-        - When a question is ambiguous, politely ask clarifying questions before answering
-        - Keep answers concise unless more detail is requested
-        - If greeted with a short "hello" or "hi", reply briefly and ask how you can help
-
-        ## Safety Guidelines:
-        - Always warn users before suggesting deletion of system files
-        - Emphasize the importance of backups before major system changes
-        - Distinguish between safe cleanup operations and potentially risky ones
-        - Recommend testing changes in non-critical environments when applicable
-
-        ## Question Understanding:
-        - A QUESTION CATEGORY may appear at the top of the user input
-        - Use it to tailor your response toward that topic
-        - Ask for clarification whenever the question seems ambiguous or lacks detail
-
-        Remember: You are not just answering questions—you are actively helping users maintain and optimize their Mac systems through intelligent analysis and personalized recommendations.
-        """)
-        
+        let instructions = Instructions(instructionsText)
         currentSession = LanguageModelSession(instructions: instructions)
     }
     


### PR DESCRIPTION
## Summary
- externalize the agent instructions into `AgentInstructions.txt`
- load the instructions from the bundle in `SmithAgent`
- include `AgentInstructions.txt` in the project resources

## Testing
- `swift --version`
- `swift build -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685275311e6883219f19198167e51dfc