### PR TITLE
Remove unused PerformanceSnapshot

### DIFF
--- a/Smith/Core/IntelligenceEngine.swift
+++ b/Smith/Core/IntelligenceEngine.swift
@@ -30,7 +30,6 @@ class IntelligenceEngine: ObservableObject {
     // MARK: - Session Intelligence
     private var sessionStartTime: Date = Date()
     private var workloadHistory: [WorkloadDetection] = []
-    private var performanceHistory: [PerformanceSnapshot] = []
     private var userInteractions: [UserInteraction] = []
     
     // MARK: - Real-Time Analysis Timer
@@ -739,15 +738,6 @@ struct WorkloadDetection {
     let timestamp: Date
     let workload: WorkloadType
     let confidence: Double
-}
-
-struct PerformanceSnapshot {
-    let timestamp: Date
-    let score: Double
-    let cpuScore: Double
-    let memoryScore: Double
-    let batteryScore: Double
-    let responsivenessScore: Double
 }
 
 struct UserInteraction {


### PR DESCRIPTION
## Summary
- clean up `IntelligenceEngine` by deleting unused `performanceHistory` property
- remove the `PerformanceSnapshot` struct since nothing references it anymore

## Testing
- `swiftc Smith/Core/IntelligenceEngine.swift -o /tmp/out 2>&1 | head -n 20` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685278bde17483219df68fa951f4f560