### PR TITLE
Implement cancel for chat generation

### DIFF
--- a/Smith/Core/FloatingPanelManager.swift
+++ b/Smith/Core/FloatingPanelManager.swift
@@ -438,7 +438,7 @@ struct FloatingQuickStatsView: View {
             HStack {
                 Button("Full Analysis") {
                     Task {
-                        await smithAgent.analyzeSystemHealth()
+                        smithAgent.analyzeSystemHealth()
                     }
                     NSApp.activate(ignoringOtherApps: true)
                 }
@@ -711,7 +711,7 @@ struct FloatingAIChatView: View {
         
         messageText = ""
         Task {
-            await smithAgent.sendMessage(message)
+            smithAgent.sendMessage(message)
         }
     }
 }

--- a/Smith/SmithApp.swift
+++ b/Smith/SmithApp.swift
@@ -38,7 +38,7 @@ struct SmithApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: .smithSendMessage)) { notification in
                     if let message = notification.object as? String {
                         Task {
-                            await smithAgent.sendMessage(message)
+                            smithAgent.sendMessage(message)
                         }
                     }
                 }
@@ -48,7 +48,7 @@ struct SmithApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: .smithShowCleanup)) { _ in
                     // Show cleanup suggestions
                     Task {
-                        await smithAgent.sendMessage("Please provide system cleanup suggestions for my Mac.")
+                        smithAgent.sendMessage("Please provide system cleanup suggestions for my Mac.")
                     }
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .smithLaunchAgentStatusChanged)) { _ in
@@ -140,7 +140,7 @@ struct SmithApp: App {
             smithAgent.setFocusedFile(fileItem)
             
             Task {
-                await smithAgent.sendMessage("Please analyze this file and tell me what it does.")
+                smithAgent.sendMessage("Please analyze this file and tell me what it does.")
             }
         }
     }
@@ -157,16 +157,16 @@ struct SmithApp: App {
             }
         case "system-health":
             Task {
-                await smithAgent.analyzeSystemHealth()
+                smithAgent.analyzeSystemHealth()
             }
         case "optimize":
             Task {
-                await smithAgent.optimizePerformance()
+                smithAgent.optimizePerformance()
             }
         case "chat":
             if let message = components?.queryItems?.first(where: { $0.name == "message" })?.value {
                 Task {
-                    await smithAgent.sendMessage(message)
+                    smithAgent.sendMessage(message)
                 }
             }
             // Bring app to front
@@ -277,7 +277,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     @objc private func quickHealthCheck() {
         Task { @MainActor in
-            await smithAgent?.analyzeSystemHealth()
+            smithAgent?.analyzeSystemHealth()
             openMainWindow()
         }
     }
@@ -289,21 +289,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     @objc private func showBatteryStatus() {
         Task { @MainActor in
-            await smithAgent?.sendMessage("Show me detailed battery status and health information")
+            smithAgent?.sendMessage("Show me detailed battery status and health information")
             openMainWindow()
         }
     }
     
     @objc private func showStorageAnalysis() {
         Task { @MainActor in
-            await smithAgent?.sendMessage("Analyze my storage usage and provide cleanup recommendations")
+            smithAgent?.sendMessage("Analyze my storage usage and provide cleanup recommendations")
             openMainWindow()
         }
     }
     
     @objc private func optimizeSystem() {
         Task { @MainActor in
-            await smithAgent?.optimizePerformance()
+            smithAgent?.optimizePerformance()
             openMainWindow()
         }
     }
@@ -318,7 +318,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let fileItem = FileItem(url: url) {
                 smithAgent?.setFocusedFile(fileItem)
                 Task { @MainActor in
-                    await smithAgent?.sendMessage("Please analyze this file/folder and provide insights.")
+                    smithAgent?.sendMessage("Please analyze this file/folder and provide insights.")
                     openMainWindow()
                 }
             }
@@ -409,7 +409,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let fileItem = FileItem(url: url) {
                 smithAgent?.setFocusedFile(fileItem)
                 Task { @MainActor in
-                    await smithAgent?.sendMessage("Please analyze this file and provide detailed insights about its purpose, contents, and recommendations.")
+                    smithAgent?.sendMessage("Please analyze this file and provide detailed insights about its purpose, contents, and recommendations.")
                     openMainWindow()
                 }
             }
@@ -421,7 +421,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         if let text = pasteboard.string(forType: .string) {
             Task { @MainActor in
-                await smithAgent?.sendMessage("Context from user selection: \(text)\n\nPlease provide insights or answer questions about this content.")
+                smithAgent?.sendMessage("Context from user selection: \(text)\n\nPlease provide insights or answer questions about this content.")
                 openMainWindow()
             }
         }
@@ -429,7 +429,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     @objc func analyzeSystemPerformanceService(_ pasteboard: NSPasteboard, userData: String, error: UnsafeMutablePointer<NSString>) {
         Task { @MainActor in
-            await smithAgent?.analyzeSystemHealth()
+            smithAgent?.analyzeSystemHealth()
             openMainWindow()
         }
     }
@@ -506,7 +506,7 @@ struct QuickStatsView: View {
             HStack {
                 Button("Full Analysis") {
                     Task {
-                        await smithAgent.analyzeSystemHealth()
+                        smithAgent.analyzeSystemHealth()
                     }
                     NSApp.activate(ignoringOtherApps: true)
                 }
@@ -621,7 +621,7 @@ struct AppQuickStatsView: View {
             HStack {
                 Button("Full Analysis") {
                     Task {
-                        await smithAgent.analyzeSystemHealth()
+                        smithAgent.analyzeSystemHealth()
                     }
                     NSApp.activate(ignoringOtherApps: true)
                 }

--- a/Smith/Views/BatteryView.swift
+++ b/Smith/Views/BatteryView.swift
@@ -156,7 +156,7 @@ struct BatteryView: View {
         let analysis = batteryMonitor.analyzeBatteryHealth()
         
         Task {
-            await smithAgent.sendMessage("Analyze my battery health and provide recommendations:\n\n\(analysis)")
+            smithAgent.sendMessage("Analyze my battery health and provide recommendations:\n\n\(analysis)")
         }
     }
     
@@ -164,7 +164,7 @@ struct BatteryView: View {
         let analysis = batteryMonitor.analyzeHighEnergyApps()
         
         Task {
-            await smithAgent.sendMessage("Which apps are draining my battery?\n\n\(analysis)")
+            smithAgent.sendMessage("Which apps are draining my battery?\n\n\(analysis)")
         }
     }
 }

--- a/Smith/Views/CPUView.swift
+++ b/Smith/Views/CPUView.swift
@@ -152,7 +152,7 @@ struct CPUView: View {
         let analysis = cpuMonitor.analyzeHighCPUUsage()
         
         Task {
-            await smithAgent.sendMessage("Analyze my current CPU usage:\n\n\(analysis)")
+            smithAgent.sendMessage("Analyze my current CPU usage:\n\n\(analysis)")
         }
     }
     
@@ -164,7 +164,7 @@ struct CPUView: View {
         let question = "Why are my CPU usage levels at \(String(format: "%.1f", cpuMonitor.cpuUsage))%? Here are my top processes:\n\n\(processesInfo)\n\nWhat should I do to optimize performance?"
         
         Task {
-            await smithAgent.sendMessage(question)
+            smithAgent.sendMessage(question)
         }
     }
     
@@ -172,7 +172,7 @@ struct CPUView: View {
         let question = "Why is \(process.name) using \(String(format: "%.1f", process.cpuUsage))% CPU? Is this normal and what can I do about it?"
         
         Task {
-            await smithAgent.sendMessage(question)
+            smithAgent.sendMessage(question)
         }
     }
 }

--- a/Smith/Views/ChatView.swift
+++ b/Smith/Views/ChatView.swift
@@ -143,7 +143,7 @@ struct ChatView: View {
     
     private func sendMessage() {
         guard !messageText.isEmpty else {
-            // Stop processing if button is pressed while processing
+            smithAgent.cancelCurrentTask()
             return
         }
         
@@ -151,7 +151,7 @@ struct ChatView: View {
         messageText = ""
         
         Task {
-            await smithAgent.sendMessage(message)
+            smithAgent.sendMessage(message)
         }
     }
 }

--- a/Smith/Views/DiskView.swift
+++ b/Smith/Views/DiskView.swift
@@ -164,7 +164,7 @@ struct DiskView: View {
         let question = "What does this file do?"
         
         Task {
-            await smithAgent.sendMessage(question)
+            smithAgent.sendMessage(question)
         }
     }
     
@@ -172,7 +172,7 @@ struct DiskView: View {
         let question = "Is this file necessary and safe to delete?"
         
         Task {
-            await smithAgent.sendMessage(question)
+            smithAgent.sendMessage(question)
         }
     }
     
@@ -180,7 +180,7 @@ struct DiskView: View {
         let question = "Please provide a detailed analysis of this file."
         
         Task {
-            await smithAgent.sendMessage(question)
+            smithAgent.sendMessage(question)
         }
     }
 }

--- a/Smith/Views/MainView.swift
+++ b/Smith/Views/MainView.swift
@@ -413,7 +413,7 @@ struct MainView: View {
                 // Quick Action Buttons
                 Button {
                     Task {
-                        await smithAgent.analyzeSystemHealth()
+                        smithAgent.analyzeSystemHealth()
                     }
                 } label: {
                     Image(systemName: "heart.text.square")
@@ -422,7 +422,7 @@ struct MainView: View {
                 
                 Button {
                     Task {
-                        await smithAgent.optimizePerformance()
+                        smithAgent.optimizePerformance()
                     }
                 } label: {
                     Image(systemName: "speedometer")

--- a/Smith/Views/MemoryView.swift
+++ b/Smith/Views/MemoryView.swift
@@ -107,7 +107,7 @@ struct MemoryView: View {
     private func askAboutProcesses() {
         let processes = memoryMonitor.topMemoryProcesses.prefix(5).map { "\($0.displayName): \(Int($0.memoryMB)) MB" }.joined(separator: "\n")
         Task {
-            await smithAgent.sendMessage("Which apps are consuming the most memory?\n\n\(processes)")
+            smithAgent.sendMessage("Which apps are consuming the most memory?\n\n\(processes)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow ChatView stop button to cancel response generation
- manage running generation tasks in `SmithAgent`
- update UI actions to match new synchronous `sendMessage`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685284644b0c8321839b38b855d0ae2b