### PR TITLE
Fix WiFi name permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Smith requests several macOS permissions on first launch:
 
 1. Open `Smith.xcodeproj` in **Xcode 15** or later.
 2. In the **Signing & Capabilities** tab for the **Smith** target, enable the **Apple Intelligence** capability. This adds the required `com.apple.developer.apple-intelligence` entitlements found in `Smith/Smith.entitlements`.
-3. Select the **Smith** scheme and click **Run** (or press <kbd>⌘R</kbd>) to build and launch the app.
+3. Still in Signing & Capabilities, enable **Access WiFi Information** so the connected network name can be displayed. This adds the `com.apple.developer.networking.wifi-info` entitlement.
+4. Select the **Smith** scheme and click **Run** (or press <kbd>⌘R</kbd>) to build and launch the app.
 
 ### Build & Run
 

--- a/Smith/Core/NetworkMonitor.swift
+++ b/Smith/Core/NetworkMonitor.swift
@@ -82,9 +82,12 @@ class NetworkMonitor: ObservableObject {
     
     func startMonitoring() {
         guard !isMonitoring else { return }
-        
+
         isMonitoring = true
-        
+
+        // Ensure location access so Wi-Fi SSID can be read
+        PermissionsManager.shared.requestLocationAccess()
+
         // Start path monitoring
         pathMonitor?.start(queue: monitorQueue)
         
@@ -241,6 +244,11 @@ class NetworkMonitor: ObservableObject {
     }
 
     private func fetchNetworkName(for path: NWPath) -> String? {
+        guard PermissionsManager.shared.locationAuthorized else {
+            logger.debug("Location permission not granted; cannot read Wi-Fi SSID")
+            return nil
+        }
+
         if path.usesInterfaceType(.wifi) {
             return CWWiFiClient.shared().interface()?.ssid()
         }

--- a/Smith/Core/PermissionsManager.swift
+++ b/Smith/Core/PermissionsManager.swift
@@ -51,7 +51,7 @@ class PermissionsManager: NSObject, ObservableObject {
         }
     }
 
-    private func requestLocationAccess() {
+    func requestLocationAccess() {
         let status = locationManager.authorizationStatus
         if status == .notDetermined {
             locationManager.requestWhenInUseAuthorization()

--- a/Smith/Info.plist
+++ b/Smith/Info.plist
@@ -34,6 +34,8 @@
         <string>Smith&apos;s Intelligence Engine uses Apple Events to monitor running applications for smart workload detection and system optimization.</string>
         <key>NSLocationUsageDescription</key>
         <string>Smith uses your current location to provide context-aware system insights.</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>Smith uses your current location to provide context-aware system insights.</string>
         <key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Smith/Smith.entitlements
+++ b/Smith/Smith.entitlements
@@ -4,5 +4,7 @@
 <dict>
         <key>com.apple.security.files.user-selected.read-write</key>
         <true/>
+        <key>com.apple.developer.networking.wifi-info</key>
+        <true/>
 </dict>
 </plist>

--- a/Smith/Views/NetworkView.swift
+++ b/Smith/Views/NetworkView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct NetworkView: View {
     @StateObject private var networkMonitor = NetworkMonitor()
+    @ObservedObject private var permissions = PermissionsManager.shared
 
     private func speedString(_ value: Double) -> String {
         String(format: "%.1f Mbps", value)
@@ -39,6 +40,13 @@ struct NetworkView: View {
                         Text("(\(networkMonitor.networkName))")
                             .font(.caption2)
                             .foregroundColor(Color.primary)
+                    } else if !permissions.locationAuthorized {
+                        Button("Allow Location") {
+                            permissions.requestLocationAccess()
+                        }
+                        .font(.caption2)
+                        .buttonStyle(.bordered)
+                        .controlSize(.mini)
                     }
                     Spacer()
 


### PR DESCRIPTION
## Summary
- expose location permission request in `PermissionsManager`
- request location access when starting network monitoring and guard SSID fetch
- add a quick location prompt in `NetworkView`
- include Wi-Fi entitlement and location description
- mention Access WiFi Information capability in build steps

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6852848242d08321b075e77c9a4907bf