### PR TITLE
Add CPU load percentage display

### DIFF
--- a/Smith/Core/CPUMonitor.swift
+++ b/Smith/Core/CPUMonitor.swift
@@ -16,6 +16,11 @@ import IOKit.ps
 @MainActor
 class CPUMonitor: ObservableObject {
     @Published var cpuUsage: Double = 0.0
+    /// Average CPU load across all cores (0-100%)
+    var cpuLoadPercentage: Double {
+        guard coreCount > 0 else { return cpuUsage }
+        return cpuUsage / Double(coreCount)
+    }
     @Published var processes: [ProcessInfo] = []
     @Published var isMonitoring = false
     @Published var coreCount: Int = 0
@@ -725,6 +730,7 @@ class CPUMonitor: ObservableObject {
         
         report += "📊 Core Count: \(coreCount)\n"
         report += "📈 Current CPU Usage: \(String(format: "%.1f", cpuUsage))%\n"
+        report += "📉 CPU Load: \(String(format: "%.1f", cpuLoadPercentage))%\n"
         report += "🌡️ Temperature: \(temperature > 0 ? "\(String(format: "%.1f", temperature))°C" : "Not available")\n"
         report += "⚡ Throttling: \(isThrottling ? "Yes" : "No")\n"
         report += "🔄 Monitoring: \(isMonitoring ? "Active" : "Inactive")\n"

--- a/Smith/Core/FloatingPanelManager.swift
+++ b/Smith/Core/FloatingPanelManager.swift
@@ -477,7 +477,10 @@ struct FloatingCPUMonitorView: View {
                     .fontWeight(.bold)
                     .foregroundColor(.green)
             }
-            
+            Text("Load: \(String(format: "%.1f", cpuMonitor.cpuLoadPercentage))%")
+                .font(.caption)
+                .foregroundColor(.primary)
+
             // CPU Usage Chart
             VStack(spacing: 8) {
                 GeometryReader { geometry in

--- a/Smith/Views/CPUView.swift
+++ b/Smith/Views/CPUView.swift
@@ -65,6 +65,15 @@ struct CPUView: View {
                                 .font(.caption2)
                                 .foregroundColor(Color.primary)
                         }
+
+                        HStack {
+                            Circle()
+                                .fill(.green)
+                                .frame(width: 4, height: 4)
+                            Text("Load: \(String(format: "%.1f", cpuMonitor.cpuLoadPercentage))%")
+                                .font(.caption2)
+                                .foregroundColor(Color.primary)
+                        }
                         
                         HStack {
                             Circle()


### PR DESCRIPTION
## Summary
- show CPU load in CPUView
- expose `cpuLoadPercentage` in `CPUMonitor`
- include load percentage in floating panel and test report

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6852d158f6a0832180a0b82f63a95a65